### PR TITLE
Minimal `HttpClient` instrumentation

### DIFF
--- a/example/weather/Program.cs
+++ b/example/weather/Program.cs
@@ -41,3 +41,4 @@ finally
 {
     await Log.CloseAndFlushAsync();
 }
+

--- a/src/SerilogTracing/Instrumentation/DiagnosticListenerObserver.cs
+++ b/src/SerilogTracing/Instrumentation/DiagnosticListenerObserver.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics;
+
+namespace SerilogTracing.Instrumentation;
+
+sealed class DiagnosticListenerObserver : IObserver<DiagnosticListener>, IDisposable
+{
+    IDisposable? _subscription;
+    
+    public void OnCompleted()
+    {
+    }
+
+    public void OnError(Exception error)
+    {
+    }
+
+    public void OnNext(DiagnosticListener value)
+    {
+        if (value.Name == "HttpHandlerDiagnosticListener")
+        {
+            _subscription = value.Subscribe(new HttpHandlerDiagnosticObserver());
+        }
+    }
+
+    public void Dispose()
+    {
+        _subscription?.Dispose();
+    }
+}

--- a/src/SerilogTracing/Instrumentation/HttpHandlerDiagnosticObserver.cs
+++ b/src/SerilogTracing/Instrumentation/HttpHandlerDiagnosticObserver.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using Serilog.Events;
+using Serilog.Parsing;
+using SerilogTracing.Interop;
+
+namespace SerilogTracing.Instrumentation;
+
+sealed class HttpHandlerDiagnosticObserver : IObserver<KeyValuePair<string,object?>>
+{
+    static readonly Func<object, HttpRequestMessage?> GetRequest = CreateAccessor<HttpRequestMessage>(
+        "System.Net.Http.DiagnosticsHandler+ActivityStartData, System.Net.Http", "Request");
+    
+    static readonly Func<object, HttpResponseMessage?> GetResponse = CreateAccessor<HttpResponseMessage>(
+        "System.Net.Http.DiagnosticsHandler+ActivityStopData, System.Net.Http", "Response");
+
+    static readonly MessageTemplate MessageTemplateOverride =
+        new MessageTemplateParser().Parse("HTTP {RequestMethod} {RequestUri}");
+    
+    public void OnCompleted()
+    {
+    }
+
+    public void OnError(Exception error)
+    {
+    }
+
+    public void OnNext(KeyValuePair<string, object?> value)
+    {
+        if (value.Value == null || Activity.Current == null) return;
+        var activity = Activity.Current;
+        
+        if (value.Key == "System.Net.Http.HttpRequestOut.Start" &&
+            activity.OperationName == "System.Net.Http.HttpRequestOut")
+        {
+            var request = GetRequest(value.Value);
+            if (request == null) return;
+            
+            activity.DisplayName = $"HTTP {request.Method} {request.RequestUri}";
+            
+            // Need to consider how much of the URI is reasonable to emit.
+            activity.AddTag("RequestUri", request.RequestUri);
+            activity.AddTag("RequestMethod", request.Method);
+            
+            ActivityUtil.SetMessageTemplateOverride(activity, MessageTemplateOverride);
+        }
+        else if (value.Key == "System.Net.Http.HttpRequestOut.Stop")
+        {
+            var response = GetResponse(value.Value);
+            if (response == null) return;
+            
+            activity.AddTag("StatusCode", (int)response.StatusCode);
+        }
+    }
+
+    static Func<object, T?> CreateAccessor<T>(string typeName, string propertyName)
+    {
+        var type = Type.GetType(typeName, throwOnError: true)!;
+        var propertyInfo = type.GetProperty(propertyName)!;
+        return receiver => (T?)propertyInfo.GetValue(receiver);
+    }
+}

--- a/src/SerilogTracing/Instrumentation/HttpHandlerDiagnosticObserver.cs
+++ b/src/SerilogTracing/Instrumentation/HttpHandlerDiagnosticObserver.cs
@@ -38,11 +38,10 @@ sealed class HttpHandlerDiagnosticObserver : IObserver<KeyValuePair<string,objec
             // Enrichment mechanism should make this customizable.
 
             activity.DisplayName = $"HTTP {request.Method} {request.RequestUri}";
+            ActivityUtil.SetMessageTemplateOverride(activity, MessageTemplateOverride);
             
             activity.AddTag("RequestUri", request.RequestUri);
             activity.AddTag("RequestMethod", request.Method);
-            
-            ActivityUtil.SetMessageTemplateOverride(activity, MessageTemplateOverride);
         }
         else if (value.Key == "System.Net.Http.HttpRequestOut.Stop")
         {

--- a/src/SerilogTracing/Instrumentation/HttpHandlerDiagnosticObserver.cs
+++ b/src/SerilogTracing/Instrumentation/HttpHandlerDiagnosticObserver.cs
@@ -34,10 +34,11 @@ sealed class HttpHandlerDiagnosticObserver : IObserver<KeyValuePair<string,objec
         {
             var request = GetRequest(value.Value);
             if (request == null) return;
-            
+
+            // Enrichment mechanism should make this customizable.
+
             activity.DisplayName = $"HTTP {request.Method} {request.RequestUri}";
             
-            // Need to consider how much of the URI is reasonable to emit.
             activity.AddTag("RequestUri", request.RequestUri);
             activity.AddTag("RequestMethod", request.Method);
             


### PR DESCRIPTION
#6 

This is still a work-in-progress, but I'm keen to see where #7 comes out before trying to generalize this feature too much.

![image](https://github.com/serilog-tracing/serilog-tracing/assets/342712/bc15800a-9e85-4311-91bf-619778549740)

Looks pretty good! There are some decisions made around activities, message templates and attached properties that should also be revisited:

 * Is the goal to update the source `Activity` for consumption by any other systems, e.g. by updating `DisplayName`? My guess is no, right now, in part because it's hard to preempt any other consumer's requirements.
 * If we're not updating `DisplayName`, is it inconsistent to be updating `Activity.Tags`? I can see ways around this via private activity properties, but I'm not sure it's worth the added complexity.

Happy letting these come out in the wash.