### PR TITLE
Zipkin sink spike

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>12</LangVersion>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <VersionPrefix>1.0.0</VersionPrefix>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    </PropertyGroup>
+</Project>

--- a/example/Example.WeatherService/Example.WeatherService.csproj
+++ b/example/Example.WeatherService/Example.WeatherService.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="serilog.sinks.console" Version="5.0.0" />
     <PackageReference Include="serilog.sinks.seq" Version="6.0.0" />
     <ProjectReference Include="../../src/SerilogTracing/SerilogTracing.csproj" />
+    <ProjectReference Include="..\..\src\SerilogTracing.Sinks.Zipkin\SerilogTracing.Sinks.Zipkin.csproj" />
   </ItemGroup>
   
 </Project>

--- a/example/Example.WeatherService/Program.cs
+++ b/example/Example.WeatherService/Program.cs
@@ -1,7 +1,10 @@
 using Serilog;
+using Serilog.Sinks.PeriodicBatching;
 using Serilog.Templates.Themes;
 using SerilogTracing;
 using SerilogTracing.Formatting;
+using SerilogTracing.Sinks.Zipkin;
+
 // ReSharper disable RedundantSuppressNullableWarningExpression
 
 Log.Logger = new LoggerConfiguration()
@@ -11,6 +14,7 @@ Log.Logger = new LoggerConfiguration()
         "http://localhost:5341",
         payloadFormatter: DefaultFormatting.CreateJsonFormatter(),
         messageHandler: new SocketsHttpHandler { ActivityHeadersPropagator = null })
+    .WriteTo.Sink(new PeriodicBatchingSink(new ZipkinSink(new Uri("http://localhost:9411")), new PeriodicBatchingSinkOptions()))
     .CreateTracingLogger();
 
 Log.Information("Weather service starting up");

--- a/example/Example.WeatherService/Program.cs
+++ b/example/Example.WeatherService/Program.cs
@@ -1,5 +1,4 @@
 using Serilog;
-using Serilog.Sinks.PeriodicBatching;
 using Serilog.Templates.Themes;
 using SerilogTracing;
 using SerilogTracing.Formatting;
@@ -14,7 +13,7 @@ Log.Logger = new LoggerConfiguration()
         "http://localhost:5341",
         payloadFormatter: DefaultFormatting.CreateJsonFormatter(),
         messageHandler: new SocketsHttpHandler { ActivityHeadersPropagator = null })
-    .WriteTo.Sink(new PeriodicBatchingSink(new ZipkinSink(new Uri("http://localhost:9411")), new PeriodicBatchingSinkOptions()))
+    .WriteTo.Zipkin("http://localhost:9411")
     .CreateTracingLogger();
 
 Log.Information("Weather service starting up");

--- a/example/weather/Program.cs
+++ b/example/weather/Program.cs
@@ -1,6 +1,5 @@
 ﻿using Serilog;
 using Serilog.Events;
-using Serilog.Sinks.PeriodicBatching;
 using Serilog.Templates.Themes;
 using SerilogTracing;
 using SerilogTracing.Formatting;
@@ -13,7 +12,7 @@ Log.Logger = new LoggerConfiguration()
         "http://localhost:5341",
         payloadFormatter: DefaultFormatting.CreateJsonFormatter(),
         messageHandler: new SocketsHttpHandler { ActivityHeadersPropagator = null })
-    .WriteTo.Sink(new PeriodicBatchingSink(new ZipkinSink(new Uri("http://localhost:9411")), new PeriodicBatchingSinkOptions()))
+    .WriteTo.Zipkin("http://localhost:9411")
     .CreateTracingLogger();
 
 if (args.Length != 1)

--- a/example/weather/Program.cs
+++ b/example/weather/Program.cs
@@ -1,8 +1,10 @@
 ﻿using Serilog;
 using Serilog.Events;
+using Serilog.Sinks.PeriodicBatching;
 using Serilog.Templates.Themes;
 using SerilogTracing;
 using SerilogTracing.Formatting;
+using SerilogTracing.Sinks.Zipkin;
 
 Log.Logger = new LoggerConfiguration()
     .Enrich.WithProperty("Application", typeof(Program).Assembly.GetName().Name)
@@ -11,6 +13,7 @@ Log.Logger = new LoggerConfiguration()
         "http://localhost:5341",
         payloadFormatter: DefaultFormatting.CreateJsonFormatter(),
         messageHandler: new SocketsHttpHandler { ActivityHeadersPropagator = null })
+    .WriteTo.Sink(new PeriodicBatchingSink(new ZipkinSink(new Uri("http://localhost:9411")), new PeriodicBatchingSinkOptions()))
     .CreateTracingLogger();
 
 if (args.Length != 1)

--- a/example/weather/weather.csproj
+++ b/example/weather/weather.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="serilog.sinks.console" Version="5.0.0" />
     <PackageReference Include="serilog.sinks.seq" Version="6.0.0" />
     <ProjectReference Include="../../src/SerilogTracing/SerilogTracing.csproj" />
+    <ProjectReference Include="..\..\src\SerilogTracing.Sinks.Zipkin\SerilogTracing.Sinks.Zipkin.csproj" />
   </ItemGroup>
 
 </Project>

--- a/serilog-tracing.sln
+++ b/serilog-tracing.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sln", "sln", "{81CA4013-44B
 		Build.ps1 = Build.ps1
 		global.json = global.json
 		Setup.ps1 = Setup.ps1
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "example", "example", "{E35D98E8-5F3C-4ABD-8A65-63B6E357DC2F}"
@@ -35,6 +36,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example.WeatherService", "e
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "weather", "example\weather\weather.csproj", "{DA47B450-39F5-4F7B-86B6-615432558136}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerilogTracing.Sinks.Zipkin", "src\SerilogTracing.Sinks.Zipkin\SerilogTracing.Sinks.Zipkin.csproj", "{5DBE6610-CCF2-41B9-9592-033B24B79558}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,6 +51,7 @@ Global
 		{13DBE96D-AA92-40E1-AABB-7109C4A12B7A} = {92FDF45D-CCCD-4BEA-A5E3-CC8ECEF34472}
 		{12A341FC-1849-439E-9C33-972A597A3DCA} = {E35D98E8-5F3C-4ABD-8A65-63B6E357DC2F}
 		{DA47B450-39F5-4F7B-86B6-615432558136} = {E35D98E8-5F3C-4ABD-8A65-63B6E357DC2F}
+		{5DBE6610-CCF2-41B9-9592-033B24B79558} = {3DF598C8-7046-4DF6-ACB1-8FB1A7BC28A3}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2D5CE076-4A88-41C1-961B-A26ABA88E6F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -66,5 +70,9 @@ Global
 		{DA47B450-39F5-4F7B-86B6-615432558136}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA47B450-39F5-4F7B-86B6-615432558136}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA47B450-39F5-4F7B-86B6-615432558136}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5DBE6610-CCF2-41B9-9592-033B24B79558}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DBE6610-CCF2-41B9-9592-033B24B79558}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DBE6610-CCF2-41B9-9592-033B24B79558}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DBE6610-CCF2-41B9-9592-033B24B79558}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/SerilogTracing.Sinks.Zipkin/Operators.cs
+++ b/src/SerilogTracing.Sinks.Zipkin/Operators.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+using Serilog.Events;
+
+namespace SerilogTracing.Sinks.Zipkin;
+
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+static class Operators
+{
+    static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    
+    public static LogEventPropertyValue? Micros(LogEventPropertyValue? value)
+    {
+        if (value is ScalarValue { Value: DateTime dt })
+            return ToMicros(dt.ToUniversalTime());
+
+        if (value is ScalarValue { Value: DateTimeOffset dto })
+            return ToMicros(dto.UtcDateTime);
+
+        return null;
+    }
+
+    static LogEventPropertyValue? ToMicros(DateTime utcDateTime)
+    {
+        if (utcDateTime < UnixEpoch) throw new ArgumentOutOfRangeException(nameof(utcDateTime));
+        var timeSinceEpoch = utcDateTime - UnixEpoch;
+        return new ScalarValue((ulong)timeSinceEpoch.Ticks / 10);
+    }
+}

--- a/src/SerilogTracing.Sinks.Zipkin/SerilogTracing.Sinks.Zipkin.csproj
+++ b/src/SerilogTracing.Sinks.Zipkin/SerilogTracing.Sinks.Zipkin.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\SerilogTracing\SerilogTracing.csproj" />
+        <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
+        <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.0-*" />
+    </ItemGroup>
+
+</Project>

--- a/src/SerilogTracing.Sinks.Zipkin/UserDefinedFunctions.cs
+++ b/src/SerilogTracing.Sinks.Zipkin/UserDefinedFunctions.cs
@@ -4,7 +4,7 @@ using Serilog.Events;
 namespace SerilogTracing.Sinks.Zipkin;
 
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
-static class Operators
+static class UserDefinedFunctions
 {
     static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     

--- a/src/SerilogTracing.Sinks.Zipkin/ZipkinLoggerSinkConfigurationExtensions.cs
+++ b/src/SerilogTracing.Sinks.Zipkin/ZipkinLoggerSinkConfigurationExtensions.cs
@@ -1,0 +1,24 @@
+using Serilog;
+using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Sinks.PeriodicBatching;
+
+namespace SerilogTracing.Sinks.Zipkin;
+
+public static class ZipkinLoggerSinkConfigurationExtensions
+{
+    public static LoggerConfiguration Zipkin(
+        this LoggerSinkConfiguration @this,
+        string endpoint, PeriodicBatchingSinkOptions? batchingOptions = null,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        LoggingLevelSwitch? levelSwitch = null)
+    {
+        batchingOptions ??= new PeriodicBatchingSinkOptions();
+        return @this.Sink(
+            new PeriodicBatchingSink(new ZipkinSink(new Uri(endpoint)), batchingOptions),
+            restrictedToMinimumLevel,
+            levelSwitch);
+    }
+}
+

--- a/src/SerilogTracing.Sinks.Zipkin/ZipkinSink.cs
+++ b/src/SerilogTracing.Sinks.Zipkin/ZipkinSink.cs
@@ -7,7 +7,7 @@ using SerilogTracing.Core;
 
 namespace SerilogTracing.Sinks.Zipkin;
 
-public class ZipkinSink: IBatchedLogEventSink
+class ZipkinSink: IBatchedLogEventSink
 {
     readonly Encoding _encoding = new UTF8Encoding(false);
     readonly HttpClient _client;
@@ -24,7 +24,7 @@ public class ZipkinSink: IBatchedLogEventSink
             tags: rest()
         }
     }
-    """, nameResolver: new StaticMemberNameResolver(typeof(Operators)));
+    """, nameResolver: new StaticMemberNameResolver(typeof(UserDefinedFunctions)));
     
     public ZipkinSink(Uri endpoint)
     {

--- a/src/SerilogTracing.Sinks.Zipkin/ZipkinSink.cs
+++ b/src/SerilogTracing.Sinks.Zipkin/ZipkinSink.cs
@@ -1,0 +1,84 @@
+using System.Text;
+using Serilog.Events;
+using Serilog.Expressions;
+using Serilog.Sinks.PeriodicBatching;
+using Serilog.Templates;
+using SerilogTracing.Core;
+
+namespace SerilogTracing.Sinks.Zipkin;
+
+public class ZipkinSink: IBatchedLogEventSink
+{
+    readonly Encoding _encoding = new UTF8Encoding(false);
+    readonly HttpClient _client;
+    readonly ExpressionTemplate _formatter = new("""
+    {
+        {
+            id: @sp,
+            traceId: @tr,
+            parentId: ParentSpanId,
+            name: @mt,
+            timestamp: Micros(SpanStartTimestamp),
+            duration: Micros(@t) - Micros(SpanStartTimestamp),
+            localEndpoint: {serviceName: Application},
+            tags: rest()
+        }
+    }
+    """, nameResolver: new StaticMemberNameResolver(typeof(Operators)));
+    
+    public ZipkinSink(Uri endpoint)
+    {
+        _client = new HttpClient { BaseAddress = endpoint };
+    }
+        
+    public async Task EmitBatchAsync(IEnumerable<LogEvent> batch)
+    {
+        // ReSharper disable MethodHasAsyncOverload
+        
+        var content = new StringWriter();
+        content.Write('[');
+        
+        var any = false;
+        foreach (var logEvent in batch.Where(IsSpan))
+        {
+            if (any)
+            {
+                content.Write(',');
+            }
+            else
+            {
+                any = true;
+            }
+            _formatter.Format(logEvent, content);
+        }
+
+        if (!any)
+        {
+            return;
+        }
+        
+        content.Write(']');
+        
+        // ReSharper restore MethodHasAsyncOverload
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "api/v2/spans")
+        {
+            Content = new StringContent(content.ToString(), _encoding, "application/json")
+        };
+
+        var response = await _client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+    }
+
+    static bool IsSpan(LogEvent logEvent)
+    {
+        return logEvent is { TraceId: not null, SpanId: not null } &&
+               logEvent.Properties.TryGetValue(Constants.SpanStartTimestampPropertyName, out var sst) &&
+               sst is ScalarValue { Value: DateTime };
+    }
+
+    public Task OnEmptyBatchAsync()
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/SerilogTracing/SerilogTracing.csproj
+++ b/src/SerilogTracing/SerilogTracing.csproj
@@ -2,12 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <LangVersion>12</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
![image](https://github.com/serilog-tracing/serilog-tracing/assets/342712/f37a827f-cbb0-4879-9481-6cd897902067)

This is very basic but even so, it seems usable. I don't think we should publish this as a package right away, but having the option to validate ideas against Zipkin locally is quite handy, and someone may wish to expand/improve it in the future.

Running a temporary Zipkin instance in Docker is as simple as:

```
docker run --rm -it -p 9411:9411 openzipkin/zipkin
```

Worth noting that it doesn't appear to support any authentication mechanism, though I may just be overlooking it.