### PR TITLE
Introduce `WriteTo.SeqTracing()`, which wraps up the formatting and message handler details

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,5 +6,6 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <VersionPrefix>1.0.0</VersionPrefix>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 </Project>

--- a/example/Example.WeatherService/Example.WeatherService.csproj
+++ b/example/Example.WeatherService/Example.WeatherService.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="serilog.aspnetcore" Version="8.0.0" />
     <PackageReference Include="serilog" Version="3.1.1" />
     <PackageReference Include="serilog.sinks.console" Version="5.0.0" />
-    <PackageReference Include="serilog.sinks.seq" Version="6.0.0" />
     <ProjectReference Include="../../src/SerilogTracing/SerilogTracing.csproj" />
+    <ProjectReference Include="..\..\src\SerilogTracing.Sinks.Seq\SerilogTracing.Sinks.Seq.csproj" />
     <ProjectReference Include="..\..\src\SerilogTracing.Sinks.Zipkin\SerilogTracing.Sinks.Zipkin.csproj" />
   </ItemGroup>
   

--- a/example/Example.WeatherService/Program.cs
+++ b/example/Example.WeatherService/Program.cs
@@ -2,6 +2,7 @@ using Serilog;
 using Serilog.Templates.Themes;
 using SerilogTracing;
 using SerilogTracing.Formatting;
+using SerilogTracing.Sinks.Seq;
 using SerilogTracing.Sinks.Zipkin;
 
 // ReSharper disable RedundantSuppressNullableWarningExpression
@@ -9,10 +10,7 @@ using SerilogTracing.Sinks.Zipkin;
 Log.Logger = new LoggerConfiguration()
     .Enrich.WithProperty("Application", typeof(Program).Assembly.GetName().Name)
     .WriteTo.Console(DefaultFormatting.CreateTextFormatter(TemplateTheme.Code))
-    .WriteTo.Seq(
-        "http://localhost:5341",
-        payloadFormatter: DefaultFormatting.CreateJsonFormatter(),
-        messageHandler: new SocketsHttpHandler { ActivityHeadersPropagator = null })
+    .WriteTo.SeqTracing("http://localhost:5341")
     .WriteTo.Zipkin("http://localhost:9411")
     .CreateTracingLogger();
 

--- a/example/weather/Program.cs
+++ b/example/weather/Program.cs
@@ -3,15 +3,13 @@ using Serilog.Events;
 using Serilog.Templates.Themes;
 using SerilogTracing;
 using SerilogTracing.Formatting;
+using SerilogTracing.Sinks.Seq;
 using SerilogTracing.Sinks.Zipkin;
 
 Log.Logger = new LoggerConfiguration()
     .Enrich.WithProperty("Application", typeof(Program).Assembly.GetName().Name)
     .WriteTo.Console(DefaultFormatting.CreateTextFormatter(TemplateTheme.Code))
-    .WriteTo.Seq(
-        "http://localhost:5341",
-        payloadFormatter: DefaultFormatting.CreateJsonFormatter(),
-        messageHandler: new SocketsHttpHandler { ActivityHeadersPropagator = null })
+    .WriteTo.SeqTracing("http://localhost:5341")
     .WriteTo.Zipkin("http://localhost:9411")
     .CreateTracingLogger();
 

--- a/example/weather/weather.csproj
+++ b/example/weather/weather.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="serilog" Version="3.1.1" />
     <PackageReference Include="serilog.sinks.console" Version="5.0.0" />
-    <PackageReference Include="serilog.sinks.seq" Version="6.0.0" />
     <ProjectReference Include="../../src/SerilogTracing/SerilogTracing.csproj" />
+    <ProjectReference Include="..\..\src\SerilogTracing.Sinks.Seq\SerilogTracing.Sinks.Seq.csproj" />
     <ProjectReference Include="..\..\src\SerilogTracing.Sinks.Zipkin\SerilogTracing.Sinks.Zipkin.csproj" />
   </ItemGroup>
 

--- a/serilog-tracing.sln
+++ b/serilog-tracing.sln
@@ -38,6 +38,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "weather", "example\weather\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerilogTracing.Sinks.Zipkin", "src\SerilogTracing.Sinks.Zipkin\SerilogTracing.Sinks.Zipkin.csproj", "{5DBE6610-CCF2-41B9-9592-033B24B79558}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerilogTracing.Sinks.Seq", "src\SerilogTracing.Sinks.Seq\SerilogTracing.Sinks.Seq.csproj", "{57AB5445-432E-4148-97BC-9953D5C162BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,6 +54,7 @@ Global
 		{12A341FC-1849-439E-9C33-972A597A3DCA} = {E35D98E8-5F3C-4ABD-8A65-63B6E357DC2F}
 		{DA47B450-39F5-4F7B-86B6-615432558136} = {E35D98E8-5F3C-4ABD-8A65-63B6E357DC2F}
 		{5DBE6610-CCF2-41B9-9592-033B24B79558} = {3DF598C8-7046-4DF6-ACB1-8FB1A7BC28A3}
+		{57AB5445-432E-4148-97BC-9953D5C162BD} = {3DF598C8-7046-4DF6-ACB1-8FB1A7BC28A3}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2D5CE076-4A88-41C1-961B-A26ABA88E6F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -74,5 +77,9 @@ Global
 		{5DBE6610-CCF2-41B9-9592-033B24B79558}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5DBE6610-CCF2-41B9-9592-033B24B79558}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5DBE6610-CCF2-41B9-9592-033B24B79558}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57AB5445-432E-4148-97BC-9953D5C162BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57AB5445-432E-4148-97BC-9953D5C162BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57AB5445-432E-4148-97BC-9953D5C162BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57AB5445-432E-4148-97BC-9953D5C162BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/serilog-tracing.sln.DotSettings
+++ b/serilog-tracing.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=uninstrumented/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/SerilogTracing.Sinks.Seq/SeqTracingLoggerSinkConfigurationExtensions.cs
+++ b/src/SerilogTracing.Sinks.Seq/SeqTracingLoggerSinkConfigurationExtensions.cs
@@ -1,0 +1,108 @@
+﻿// Based on code from Serilog.Sinks.Seq with modifications by
+// SerilogTracing contributors.
+
+// Serilog.Sinks.Seq Copyright © Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog;
+using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Templates;
+
+namespace SerilogTracing.Sinks.Seq;
+
+/// <summary>
+/// Extends Serilog configuration to write og events and traces to Seq.
+/// </summary>
+public static class SeqTracingLoggerSinkConfigurationExtensions
+{
+    static ITextFormatter CreatePayloadFormatter() => new ExpressionTemplate(
+        "{ {@t, @mt, @l: if @l = 'Information' then undefined() else @l, @x, @sp, @tr, @ps: ParentSpanId, @st: SpanStartTimestamp, ..rest()} }\n");
+
+    static HttpMessageHandler CreateSilentHttpMessageHandler() =>
+        new SocketsHttpHandler { ActivityHeadersPropagator = null };
+    
+    /// <summary>
+    /// Write log events and traces to a <a href="https://datalust.co/seq">Seq</a> server.
+    /// </summary>
+    /// <param name="loggerSinkConfiguration">The logger configuration.</param>
+    /// <param name="serverUrl">The base URL of the Seq server that log events will be written to.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum log event level required
+    /// in order to write an event to the sink.</param>
+    /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+    /// <param name="period">The time to wait between checking for event batches.</param>
+    /// <param name="bufferBaseFilename">Path for a set of files that will be used to buffer events until they
+    /// can be successfully transmitted across the network. Individual files will be created using the
+    /// pattern <paramref name="bufferBaseFilename" />*.json, which should not clash with any other filenames
+    /// in the same directory.</param>
+    /// <param name="apiKey">A Seq <i>API key</i> that authenticates the client to the Seq server.</param>
+    /// <param name="bufferSizeLimitBytes">The maximum amount of data, in bytes, to which the buffer
+    /// log file for a specific date will be allowed to grow. By default no limit will be applied.</param>
+    /// <param name="eventBodyLimitBytes">The maximum size, in bytes, that the JSON representation of
+    /// an event may take before it is dropped rather than being sent to the Seq server. Specify null for no limit.
+    /// The default is 265 KB.</param>
+    /// <param name="controlLevelSwitch">If provided, the switch will be updated based on the Seq server's level setting
+    /// for the corresponding API key. Passing the same key to MinimumLevel.ControlledBy() will make the whole pipeline
+    /// dynamically controlled. Do not specify <paramref name="restrictedToMinimumLevel" /> with this setting.</param>
+    /// <param name="messageHandler">Used to construct the HttpClient that will send the log messages to Seq.</param>
+    /// <param name="retainedInvalidPayloadsLimitBytes">A soft limit for the number of bytes to use for storing failed requests.
+    /// The limit is soft in that it can be exceeded by any single error payload, but in that case only that single error
+    /// payload will be retained.</param>
+    /// <param name="queueSizeLimit">The maximum number of events that will be held in-memory while waiting to ship them to
+    /// Seq. Beyond this limit, events will be dropped. The default is 100,000. Has no effect on
+    /// durable log shipping.</param>
+    /// <returns>Logger configuration, allowing configuration to continue.</returns>
+    /// <exception cref="T:System.ArgumentNullException">A required parameter is null.</exception>
+    /// <remarks>
+    /// This extension differs from the default one by overriding the payload formatter with a tracing-aware one. The
+    /// extension also defaults <paramref name="messageHandler"/> to an uninstrumented one, so that outbound requests
+    /// from the sink don't end up generating spans. If a custom message handler is passed, ensure
+    /// <see cref="SocketsHttpHandler.ActivityHeadersPropagator"/> or its equivalent is set to <c>null</c>.
+    /// </remarks>
+    public static LoggerConfiguration SeqTracing(
+      this LoggerSinkConfiguration loggerSinkConfiguration,
+      string serverUrl,
+      LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose,
+      int batchPostingLimit = 1000,
+      TimeSpan? period = null,
+      string? apiKey = null,
+      string? bufferBaseFilename = null,
+      long? bufferSizeLimitBytes = null,
+      long? eventBodyLimitBytes = 262144,
+      LoggingLevelSwitch? controlLevelSwitch = null,
+      HttpMessageHandler? messageHandler = null,
+      long? retainedInvalidPayloadsLimitBytes = null,
+      int queueSizeLimit = 100000)
+    {
+      if (loggerSinkConfiguration == null)
+          throw new ArgumentNullException(nameof (loggerSinkConfiguration));
+
+      return loggerSinkConfiguration.Seq(
+          serverUrl,
+          restrictedToMinimumLevel,
+          batchPostingLimit,
+          period,
+          apiKey,
+          bufferBaseFilename,
+          bufferSizeLimitBytes,
+          eventBodyLimitBytes,
+          controlLevelSwitch,
+          messageHandler ?? CreateSilentHttpMessageHandler(),
+          retainedInvalidPayloadsLimitBytes,
+          queueSizeLimit,
+          CreatePayloadFormatter());
+    }
+}

--- a/src/SerilogTracing.Sinks.Seq/SerilogTracing.Sinks.Seq.csproj
+++ b/src/SerilogTracing.Sinks.Seq/SerilogTracing.Sinks.Seq.csproj
@@ -7,7 +7,7 @@
     <ItemGroup>
         <ProjectReference Include="..\SerilogTracing\SerilogTracing.csproj" />
         <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
-        <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.0-*" />
+        <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/SerilogTracing.Sinks.Zipkin/ZipkinLoggerSinkConfigurationExtensions.cs
+++ b/src/SerilogTracing.Sinks.Zipkin/ZipkinLoggerSinkConfigurationExtensions.cs
@@ -6,19 +6,42 @@ using Serilog.Sinks.PeriodicBatching;
 
 namespace SerilogTracing.Sinks.Zipkin;
 
+/// <summary>
+/// Extends Serilog's <c>WriteTo</c> object with the <see cref="Zipkin"/> method.
+/// </summary>
 public static class ZipkinLoggerSinkConfigurationExtensions
 {
+    /// <summary>
+    /// Send trace data to a Zipkin server.
+    /// </summary>
+    /// <param name="this">The configuration object that is extended.</param>
+    /// <param name="endpoint">The URL of the Zipkin instance, for example, <c>http://localhost:9411</c>.</param>
+    /// <param name="configureBatchingOptions">Optionally, a callback that can modify how spans are collected into
+    /// batches before delivery to the sink.</param>
+    /// <param name="messageHandler">Optionally, an <see cref="HttpMessageHandler"/> used when sending request to
+    /// Zipkin. The default handler disables instrumentation of outbound requests so that the sink does not
+    /// inadvertently generate traces.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for
+    /// events passed through the sink. Ignored when <paramref name="levelSwitch" /> is specified.</param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+    /// to be changed at runtime.</param>
+    /// <returns>Configuration object allowing method chaining.</returns>
     public static LoggerConfiguration Zipkin(
         this LoggerSinkConfiguration @this,
-        string endpoint, PeriodicBatchingSinkOptions? batchingOptions = null,
+        string endpoint,
+        Action<PeriodicBatchingSinkOptions>? configureBatchingOptions = null,
+        HttpMessageHandler? messageHandler = null,
         LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
         LoggingLevelSwitch? levelSwitch = null)
     {
-        batchingOptions ??= new PeriodicBatchingSinkOptions();
+        var batchingOptions = new PeriodicBatchingSinkOptions();
+        configureBatchingOptions?.Invoke(batchingOptions);
+        
+        messageHandler ??= new SocketsHttpHandler { ActivityHeadersPropagator = null };
+
         return @this.Sink(
-            new PeriodicBatchingSink(new ZipkinSink(new Uri(endpoint)), batchingOptions),
+            new PeriodicBatchingSink(new ZipkinSink(new Uri(endpoint), messageHandler), batchingOptions),
             restrictedToMinimumLevel,
             levelSwitch);
     }
 }
-

--- a/src/SerilogTracing/Formatting/DefaultFormatting.cs
+++ b/src/SerilogTracing/Formatting/DefaultFormatting.cs
@@ -26,17 +26,4 @@ public static class DefaultFormatting
             theme: theme,
             nameResolver: new TracingFunctionsNameResolver());
     }
-
-    /// <summary>
-    /// Produces a JSON format based on the one used by Serilog.Formatting.Compact, which is also compatible with the format
-    /// accepted by Seq.
-    /// </summary>
-    /// <param name="theme">Optional template theme to apply, useful only for ANSI console output.</param>
-    /// <returns>The formatter.</returns>
-    public static ITextFormatter CreateJsonFormatter(TemplateTheme? theme = null)
-    {
-        return new ExpressionTemplate(
-            "{ {@t, @mt, @l: if @l = 'Information' then undefined() else @l, @x, @sp, @tr, @ps: ParentSpanId, @st: SpanStartTimestamp, ..rest()} }\n",
-            theme: theme);
-    }
 }

--- a/src/SerilogTracing/Instrumentation/HttpHandlerDiagnosticObserver.cs
+++ b/src/SerilogTracing/Instrumentation/HttpHandlerDiagnosticObserver.cs
@@ -53,6 +53,7 @@ sealed class HttpHandlerDiagnosticObserver : IObserver<KeyValuePair<string,objec
             };
 
             ActivityUtil.SetMessageTemplateOverride(activity, MessageTemplateOverride);
+            activity.DisplayName = MessageTemplateOverride.Text;
             activity.AddTag("RequestUri", uriBuilder.Uri);
             activity.AddTag("RequestMethod", request.Method);
         }

--- a/test/SerilogTracing.Tests/SerilogTracing.Tests.csproj
+++ b/test/SerilogTracing.Tests/SerilogTracing.Tests.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../assets/SerilogTracing.snk</AssemblyOriginatorKeyFile>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part 1 of #13 

![image](https://github.com/serilog-tracing/serilog-tracing/assets/342712/d8c3b206-53f7-40f4-9d72-5cdbacdef181)

The PR also improves the `HttpClient` instrumentation by setting the activity status on the two failure paths.