### PR TITLE
Don't include the commit hash in SerilogTracing.Sinks.OpenTelemetry's `AssemblyInformationalVersion`

### DIFF
--- a/src/SerilogTracing.Sinks.OpenTelemetry/SerilogTracing.Sinks.OpenTelemetry.csproj
+++ b/src/SerilogTracing.Sinks.OpenTelemetry/SerilogTracing.Sinks.OpenTelemetry.csproj
@@ -18,6 +18,7 @@
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\..\assets\SerilogTracing.snk</AssemblyOriginatorKeyFile>
+		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 	</PropertyGroup>
 	
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">


### PR DESCRIPTION
![image](https://github.com/serilog-tracing/serilog-tracing/assets/342712/c80e5e71-0a1f-4910-bb03-8f345bfa3c66)

See also https://github.com/dotnet/sdk/issues/34568
