### PR TITLE
Activity instrumentation tidy-up

### DIFF
--- a/serilog-tracing.sln
+++ b/serilog-tracing.sln
@@ -48,6 +48,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerilogTracing.Expressions"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerilogTracing.Instrumentation.AspNetCore", "src\SerilogTracing.Instrumentation.AspNetCore\SerilogTracing.Instrumentation.AspNetCore.csproj", "{A41C8092-0527-4A83-85A3-6FECBA531E21}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerilogTracing.Instrumentation.AspNetCore.Tests", "test\SerilogTracing.Instrumentation.AspNetCore.Tests\SerilogTracing.Instrumentation.AspNetCore.Tests.csproj", "{6E4D6C66-3611-4037-BD31-A039A78824A5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -67,6 +69,7 @@ Global
 		{57AB5445-432E-4148-97BC-9953D5C162BD} = {3DF598C8-7046-4DF6-ACB1-8FB1A7BC28A3}
 		{586FD369-EF68-49E0-B827-A35218E1E4E5} = {3DF598C8-7046-4DF6-ACB1-8FB1A7BC28A3}
 		{A41C8092-0527-4A83-85A3-6FECBA531E21} = {3DF598C8-7046-4DF6-ACB1-8FB1A7BC28A3}
+		{6E4D6C66-3611-4037-BD31-A039A78824A5} = {92FDF45D-CCCD-4BEA-A5E3-CC8ECEF34472}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2D5CE076-4A88-41C1-961B-A26ABA88E6F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -109,5 +112,9 @@ Global
 		{A41C8092-0527-4A83-85A3-6FECBA531E21}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A41C8092-0527-4A83-85A3-6FECBA531E21}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A41C8092-0527-4A83-85A3-6FECBA531E21}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E4D6C66-3611-4037-BD31-A039A78824A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E4D6C66-3611-4037-BD31-A039A78824A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E4D6C66-3611-4037-BD31-A039A78824A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E4D6C66-3611-4037-BD31-A039A78824A5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentationOptions.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentationOptions.cs
@@ -7,7 +7,7 @@ namespace SerilogTracing.Instrumentation.AspNetCore;
 /// <summary>
 /// Configuration for a <see cref="HttpRequestInActivityInstrumentor"/>.
 /// </summary>
-public sealed class HttpRequestInActivityInstrumentorOptions
+public sealed class HttpRequestInActivityInstrumentationOptions
 {
     const string DefaultRequestCompletionMessageTemplate =
         "HTTP {RequestMethod} {RequestPath}";
@@ -28,7 +28,7 @@ public sealed class HttpRequestInActivityInstrumentorOptions
     /// <summary>
     /// Construct a default set of options.
     /// </summary>
-    public HttpRequestInActivityInstrumentorOptions()
+    public HttpRequestInActivityInstrumentationOptions()
     {
         MessageTemplate = DefaultRequestCompletionMessageTemplate;
         GetRequestProperties = DefaultGetRequestProperties;

--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
@@ -8,12 +8,12 @@ namespace SerilogTracing.Instrumentation.AspNetCore;
 /// <summary>
 /// An activity instrumentor that populates the current activity with context from incoming HTTP requests.
 /// </summary>
-public sealed class HttpRequestInActivityInstrumentor: IActivityInstrumentor
+sealed class HttpRequestInActivityInstrumentor: IActivityInstrumentor
 {
     /// <summary>
     /// Create an instance of the instrumentor.
     /// </summary>
-    public HttpRequestInActivityInstrumentor(HttpRequestInActivityInstrumentorOptions options)
+    public HttpRequestInActivityInstrumentor(HttpRequestInActivityInstrumentationOptions options)
     {
         _getRequestProperties = options.GetRequestProperties;
         _getResponseProperties = options.GetResponseProperties;

--- a/src/SerilogTracing.Instrumentation.AspNetCore/TracingInstrumentationConfigurationAspNetCoreExtensions.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/TracingInstrumentationConfigurationAspNetCoreExtensions.cs
@@ -1,11 +1,12 @@
-﻿using SerilogTracing.Instrumentation.AspNetCore;
+﻿using SerilogTracing.Configuration;
+using SerilogTracing.Instrumentation.AspNetCore;
 
 namespace SerilogTracing;
 
 /// <summary>
 /// Support ASP.NET Core instrumentation.
 /// </summary>
-public static class InstrumentationOptionsExtensions
+public static class TracingInstrumentationConfigurationAspNetCoreExtensions
 {
     /// <summary>
     /// Add instrumentation for ASP.NET Core requests.
@@ -23,9 +24,9 @@ public static class InstrumentationOptionsExtensions
     /// <param name="with">A callback to configure the instrumentation.</param>
     /// <returns>Configuration object allowing method chaining.</returns>
     public static TracingConfiguration AspNetCoreRequests(
-        this TracingInstrumentationConfiguration configuration, Action<HttpRequestInActivityInstrumentorOptions> with)
+        this TracingInstrumentationConfiguration configuration, Action<HttpRequestInActivityInstrumentationOptions> with)
     {
-        var httpOptions = new HttpRequestInActivityInstrumentorOptions();
+        var httpOptions = new HttpRequestInActivityInstrumentationOptions();
         with.Invoke(httpOptions);
         
         return configuration.With(new HttpRequestInActivityInstrumentor(httpOptions));

--- a/src/SerilogTracing/Configuration/TracingInstrumentationConfiguration.cs
+++ b/src/SerilogTracing/Configuration/TracingInstrumentationConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using SerilogTracing.Instrumentation;
+using SerilogTracing.Instrumentation.HttpClient;
 
-namespace SerilogTracing;
+namespace SerilogTracing.Configuration;
 
 /// <summary>
 /// Controls instrumentation configuration.

--- a/src/SerilogTracing/Configuration/TracingSamplingConfiguration.cs
+++ b/src/SerilogTracing/Configuration/TracingSamplingConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 
-namespace SerilogTracing;
+namespace SerilogTracing.Configuration;
 
 /// <summary>
 /// Options for <see cref="TracingConfiguration"/> configuration.

--- a/src/SerilogTracing/Instrumentation/ActivityInstrumentation.cs
+++ b/src/SerilogTracing/Instrumentation/ActivityInstrumentation.cs
@@ -36,7 +36,7 @@ public static class ActivityInstrumentation
     /// <param name="activity">The activity containing the message template.</param>
     /// <param name="messageTemplate">The assigned message template, if any.</param>
     /// <returns>True when the activity contains a message template.</returns>
-    public static bool TryGetMessageTemplateOverride(Activity activity, [NotNullWhen(true)] out MessageTemplate? messageTemplate)
+    internal static bool TryGetMessageTemplateOverride(Activity activity, [NotNullWhen(true)] out MessageTemplate? messageTemplate)
     {
         if (activity.GetCustomProperty(Constants.MessageTemplateOverridePropertyName) is MessageTemplate customPropertyValue)
         {
@@ -100,7 +100,7 @@ public static class ActivityInstrumentation
     /// </summary>
     /// <param name="activity">The activity containing the properties.</param>
     /// <returns>A collection of properties set on the activity.</returns>
-    public static IEnumerable<LogEventProperty> GetLogEventProperties(Activity activity)
+    internal static IEnumerable<LogEventProperty> GetLogEventProperties(Activity activity)
     {
         return TryGetLogEventPropertyCollection(activity, out var existing) ? existing.Values : Enumerable.Empty<LogEventProperty>();
     }
@@ -166,7 +166,7 @@ public static class ActivityInstrumentation
     /// <param name="exception">True if an exception event is present on the activity. The type of the returned
     /// exception is not guaranteed to match the one originally set on the activity.</param>
     /// <returns></returns>
-    public static bool TryGetException(Activity activity, [NotNullWhen(true)] out Exception? exception)
+    internal static bool TryGetException(Activity activity, [NotNullWhen(true)] out Exception? exception)
     {
         exception = ExceptionFromEvents(activity);
 
@@ -200,7 +200,7 @@ public static class ActivityInstrumentation
     /// <returns>A <see cref="LogEventLevel"/> based on <see cref="Activity.Status"/>. If the status is
     /// <see cref="ActivityStatusCode.Error"/> then the completion value will be <see cref="LogEventLevel.Error"/>.
     /// Otherwise it'll be <see cref="LogEventLevel.Information"/>.</returns>
-    public static LogEventLevel GetCompletionLevel(Activity activity)
+    internal static LogEventLevel GetCompletionLevel(Activity activity)
     {
         return activity.Status == ActivityStatusCode.Error ? LogEventLevel.Error : LogEventLevel.Information;
     }

--- a/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentor.cs
@@ -2,19 +2,13 @@
 using Serilog.Events;
 using Serilog.Parsing;
 
-namespace SerilogTracing.Instrumentation;
+namespace SerilogTracing.Instrumentation.HttpClient;
 
 /// <summary>
-/// An activity enricher that populates the current activity with context from outgoing HTTP requests.
+/// An activity instrumentor that populates the current activity with context from outgoing HTTP requests.
 /// </summary>
-public sealed class HttpRequestOutActivityInstrumentor: IActivityInstrumentor
+sealed class HttpRequestOutActivityInstrumentor: IActivityInstrumentor
 {
-    /// <summary>
-    /// Create an instance of the enricher.
-    /// </summary>
-    public HttpRequestOutActivityInstrumentor()
-    {}
-    
     /// <inheritdoc cref="IActivityInstrumentor.ShouldSubscribeTo"/>
     public bool ShouldSubscribeTo(string diagnosticListenerName)
     {
@@ -40,10 +34,10 @@ public sealed class HttpRequestOutActivityInstrumentor: IActivityInstrumentor
 
                 var uriBuilder = new UriBuilder(request.RequestUri)
                 {
-                    Query = null,
-                    Fragment = null,
-                    UserName = null,
-                    Password = null
+                    Query = null!,
+                    Fragment = null!,
+                    UserName = null!,
+                    Password = null!
                 };
 
                 ActivityInstrumentation.SetMessageTemplateOverride(activity, MessageTemplateOverride);

--- a/src/SerilogTracing/Instrumentation/IActivityInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/IActivityInstrumentor.cs
@@ -13,7 +13,7 @@ public interface IActivityInstrumentor
     /// <param name="diagnosticListenerName">The <see cref="DiagnosticListener.Name"/> of the candidate <see cref="DiagnosticListener"/>.</param>
     /// <returns>Whether the instrumentor should receive events from the given listener.</returns>
     bool ShouldSubscribeTo(string diagnosticListenerName);
-    
+
     /// <summary>
     /// Enrich the an activity with context from a diagnostic event.
     /// </summary>

--- a/src/SerilogTracing/TracingConfiguration.cs
+++ b/src/SerilogTracing/TracingConfiguration.cs
@@ -3,6 +3,7 @@ using Serilog;
 using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
+using SerilogTracing.Configuration;
 using SerilogTracing.Instrumentation;
 using SerilogTracing.Interop;
 

--- a/src/SerilogTracing/TracingInstrumentationConfigurationHttpClientExtensions.cs
+++ b/src/SerilogTracing/TracingInstrumentationConfigurationHttpClientExtensions.cs
@@ -1,0 +1,19 @@
+﻿using SerilogTracing.Configuration;
+using SerilogTracing.Instrumentation.HttpClient;
+
+namespace SerilogTracing;
+
+/// <summary>
+/// Support ASP.NET Core instrumentation.
+/// </summary>
+public static class TracingInstrumentationConfigurationHttpClientExtensions
+{
+    /// <summary>
+    /// Add instrumentation for ASP.NET Core requests.
+    /// </summary>
+    /// <returns></returns>
+    public static TracingConfiguration HttpClientRequests(this TracingInstrumentationConfiguration configuration)
+    {
+        return configuration.With(new HttpRequestOutActivityInstrumentor());
+    }
+}

--- a/test/SerilogTracing.Instrumentation.AspNetCore.Tests/SerilogTracing.Instrumentation.AspNetCore.Tests.csproj
+++ b/test/SerilogTracing.Instrumentation.AspNetCore.Tests/SerilogTracing.Instrumentation.AspNetCore.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net8.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>../../assets/SerilogTracing.snk</AssemblyOriginatorKeyFile>
+        <IsPackable>false</IsPackable>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="xunit" Version="2.6.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" PrivateAssets="All" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\SerilogTracing.Instrumentation.AspNetCore\SerilogTracing.Instrumentation.AspNetCore.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/SerilogTracing.Instrumentation.AspNetCore.Tests/TracingInstrumentationConfigurationAspNetCoreExtensionsTests.cs
+++ b/test/SerilogTracing.Instrumentation.AspNetCore.Tests/TracingInstrumentationConfigurationAspNetCoreExtensionsTests.cs
@@ -1,0 +1,15 @@
+﻿using Xunit;
+
+namespace SerilogTracing.Instrumentation.AspNetCore.Tests;
+
+public class TracingInstrumentationConfigurationAspNetCoreExtensionsTests
+{
+    [Fact]
+    public void ConfigurationMethodsAreCallable()
+    {
+        var configuration = new TracingConfiguration();
+
+        configuration.Instrument.AspNetCoreRequests();
+        configuration.Instrument.AspNetCoreRequests(_ => { });
+    }
+}

--- a/test/SerilogTracing.Tests/TracingConfigurationTests.cs
+++ b/test/SerilogTracing.Tests/TracingConfigurationTests.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace SerilogTracing.Tests;
+
+public class TracingConfigurationTests
+{
+    [Fact]
+    public void TracingConfigurationMethodsAreCallable()
+    {
+        // At this stage just covers some code paths that are
+        // otherwise uncalled: not yet verifying outcomes, but
+        // will at least pick up on obvious things like NREs.
+
+        var configuration = new TracingConfiguration();
+
+        configuration.Instrument.WithDefaultInstrumentation(true);
+        configuration.Instrument.WithDefaultInstrumentation(false);
+        configuration.Instrument.HttpClientRequests();
+
+        configuration.Sample.UsingActivityContext((ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.None);
+        configuration.Sample.UsingParentId((ref ActivityCreationOptions<string> _) => ActivitySamplingResult.None);
+    }
+}


### PR DESCRIPTION
 * Adds an `Instrument.HttpClientRequests()` method that can be used after calling `WithDefaultInstrumentors(false)` to add back _just_ the `HttpClient` request instrumentation (assuming other defaults may exist in the future).
 * Internalizes the activity instrumentor classes - harder to evolve these when they're public
 * Internalizes `ActivityInstrumentation.Get*` - we haven't planned out a high-fidelity public `Activity` <> `LogEvent` mapping, best to reflect that in the API (and the `Set` methods may eventually move to an object provided to `IActivityInstrumentor.InstrumentActivity()).
 * Moves the configuration objects for sampling and instrumentation into `SerilogTracing.Configuration` - these don't need to be in the root `SerilogTracing` namespace
 * Adds some trivial test stubs for some previously uncalled configuration methods