### PR TITLE
Add `TraceTo(ILogger)` and `TraceToSharedLogger()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Log.Logger = new LoggerConfiguration()
     .WriteTo.Console(Formatters.CreateConsoleTextFormatter())
     .CreateLogger();
 
-using var _ = new TracingConfiguration().EnableTracing();
+using var _ = new TracingConfiguration().TraceToStaticLogger();
 
 using var activity = Log.Logger.StartActivity("Check {Host}", "example.com");
 try
@@ -85,15 +85,29 @@ Log.Logger = new LoggerConfiguration()
 
 The `Formatters.CreateConsoleTextFormatter()` function comes from `SerilogTracing.Expressions`; you can ignore this and use a regular console output template, but the one we're using here produces nice output for spans that includes timing information. Dig into the implementation of the `CreateConsoleTextFormatter()` function if you'd like to see how to set up your own trace-specific formatting, it's pretty straightforward.
 
-### Enabling tracing with `TracingConfiguration.EnableTracing()`
+### Enabling tracing with `TracingConfiguration.TraceToStaticLogger()`
 
 This line sets up SerilogTracing's integration with .NET's diagnostic sources, and starts an activity listener in the background that will write spans from the framework and third-party libraries through your Serilog pipeline:
 
 ```csharp
-using var _ = new TracingConfiguration().EnableTracing();
+using var _ = new TracingConfiguration().TraceToStaticLogger();
 ```
 
 This step is optional, but you'll need this if you want to view your SerilogTracing output as hierarchical, distributed traces: without it, `HttpClient` won't generate spans, and won't propagate trace ids along with outbound HTTP requests.
+
+You can also configure SerilogTracing to send spans through a specific `ILogger`:
+
+```csharp
+using Serilog;
+using SerilogTracing;
+using SerilogTracing.Expressions;
+
+await using var logger = new LoggerConfiguration()
+    .WriteTo.Console(Formatters.CreateConsoleTextFormatter())
+    .CreateLogger();
+
+using var _ = new TracingConfiguration().TraceTo(logger);
+```
 
 ### Starting and completing activities
 
@@ -146,7 +160,7 @@ Then add `Instrument.AspNetCoreRequests()` to your `TracingConfiguration`:
 ```csharp
 using var _ = new TracingConfiguration()
     .Instrument.AspNetCoreRequests()
-    .EnableTracing();
+    .TraceToStaticLogger();
 ```
 
 ## How are traces represented as `LogEvent`s?

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Log.Logger = new LoggerConfiguration()
     .WriteTo.Console(Formatters.CreateConsoleTextFormatter())
     .CreateLogger();
 
-using var _ = new TracingConfiguration().TraceToStaticLogger();
+using var _ = new TracingConfiguration().TraceToSharedLogger();
 
 using var activity = Log.Logger.StartActivity("Check {Host}", "example.com");
 try
@@ -85,12 +85,12 @@ Log.Logger = new LoggerConfiguration()
 
 The `Formatters.CreateConsoleTextFormatter()` function comes from `SerilogTracing.Expressions`; you can ignore this and use a regular console output template, but the one we're using here produces nice output for spans that includes timing information. Dig into the implementation of the `CreateConsoleTextFormatter()` function if you'd like to see how to set up your own trace-specific formatting, it's pretty straightforward.
 
-### Enabling tracing with `TracingConfiguration.TraceToStaticLogger()`
+### Enabling tracing with `TracingConfiguration.TraceToSharedLogger()`
 
 This line sets up SerilogTracing's integration with .NET's diagnostic sources, and starts an activity listener in the background that will write spans from the framework and third-party libraries through your Serilog pipeline:
 
 ```csharp
-using var _ = new TracingConfiguration().TraceToStaticLogger();
+using var _ = new TracingConfiguration().TraceToSharedLogger();
 ```
 
 This step is optional, but you'll need this if you want to view your SerilogTracing output as hierarchical, distributed traces: without it, `HttpClient` won't generate spans, and won't propagate trace ids along with outbound HTTP requests.
@@ -160,7 +160,7 @@ Then add `Instrument.AspNetCoreRequests()` to your `TracingConfiguration`:
 ```csharp
 using var _ = new TracingConfiguration()
     .Instrument.AspNetCoreRequests()
-    .TraceToStaticLogger();
+    .TraceToSharedLogger();
 ```
 
 ## How are traces represented as `LogEvent`s?

--- a/example/Example.WeatherService/Program.cs
+++ b/example/Example.WeatherService/Program.cs
@@ -19,7 +19,7 @@ Log.Logger = new LoggerConfiguration()
 
 using var _ = new TracingConfiguration()
     .Instrument.AspNetCoreRequests()
-    .TraceToStaticLogger();
+    .TraceToSharedLogger();
 
 Log.Information("Weather service starting up");
 

--- a/example/Example.WeatherService/Program.cs
+++ b/example/Example.WeatherService/Program.cs
@@ -19,7 +19,7 @@ Log.Logger = new LoggerConfiguration()
 
 using var _ = new TracingConfiguration()
     .Instrument.AspNetCoreRequests()
-    .EnableTracing();
+    .TraceToStaticLogger();
 
 Log.Information("Weather service starting up");
 

--- a/example/weather/Program.cs
+++ b/example/weather/Program.cs
@@ -16,7 +16,7 @@ Log.Logger = new LoggerConfiguration()
     })
     .CreateLogger();
 
-using var _ = new TracingConfiguration().TraceToStaticLogger();
+using var _ = new TracingConfiguration().TraceToSharedLogger();
 
 if (args.Length != 1)
 {

--- a/example/weather/Program.cs
+++ b/example/weather/Program.cs
@@ -17,7 +17,7 @@ Log.Logger = new LoggerConfiguration()
     })
     .CreateLogger();
 
-using var _ = new TracingConfiguration().EnableTracing();
+using var _ = new TracingConfiguration().TraceToStaticLogger();
 
 if (args.Length != 1)
 {

--- a/src/SerilogTracing/TracingConfiguration.cs
+++ b/src/SerilogTracing/TracingConfiguration.cs
@@ -37,16 +37,46 @@ public class TracingConfiguration
     /// Completes configuration and returns a handle that can be used to shut tracing down when no longer required.
     /// </summary>
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
+    [Obsolete("Use TraceTo(ILogger) or TraceToStaticLogger()")]
     public IDisposable EnableTracing(ILogger? logger = null)
+    {
+        return logger != null ? TraceTo(logger) : TraceToStaticLogger();
+    }
+
+    /// <summary>
+    /// Completes configuration and returns a handle that can be used to shut tracing down when no longer required.
+    /// </summary>
+    /// <param name="logger">The logger instance to emit traces through. Avoid using the shared <see cref="Log.Logger"/> as
+    /// the value here. To emit traces through the shared static logger, call <see cref="TraceToStaticLogger"/> instead.</param>
+    /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
+    public IDisposable TraceTo(ILogger logger)
+    {
+        return EnableTracing(() => logger);
+    }
+
+    /// <summary>
+    /// Completes configuration and returns a handle that can be used to shut tracing down when no longer required.
+    ///
+    /// This method is not equivalent to <code>TraceTo(Log.Logger)</code>. The former will emit traces through whatever the
+    /// value of <see cref="Log.Logger"/> happened to be at the time <see cref="TraceTo"/> was called. This method
+    /// will always emit traces through the current value of <see cref="Log.Logger"/>.
+    /// </summary>
+    /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
+    public IDisposable TraceToStaticLogger()
+    {
+        return EnableTracing(() => Log.Logger);
+    }
+
+    IDisposable EnableTracing(Func<ILogger> logger)
     {
         var instrumentors = Instrument.GetInstrumentors().ToArray();
         var activityListener = new ActivityListener();
         var diagnosticListenerSubscription = DiagnosticListener.AllListeners.Subscribe(new DiagnosticListenerObserver(instrumentors));
         var disposeProxy = new DisposeProxy(diagnosticListenerSubscription, activityListener);
-
+        
         ILogger GetLogger(string name)
         {
-            var instance = logger ?? Log.Logger;
+            var instance = logger();
             return !string.IsNullOrWhiteSpace(name) ? instance.ForContext(Constants.SourceContextPropertyName, name) : instance;
         }
 

--- a/src/SerilogTracing/TracingConfiguration.cs
+++ b/src/SerilogTracing/TracingConfiguration.cs
@@ -37,17 +37,17 @@ public class TracingConfiguration
     /// Completes configuration and returns a handle that can be used to shut tracing down when no longer required.
     /// </summary>
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
-    [Obsolete("Use TraceTo(ILogger) or TraceToStaticLogger()")]
+    [Obsolete("Use TraceTo(ILogger) or TraceToSharedLogger()")]
     public IDisposable EnableTracing(ILogger? logger = null)
     {
-        return logger != null ? TraceTo(logger) : TraceToStaticLogger();
+        return logger != null ? TraceTo(logger) : TraceToSharedLogger();
     }
 
     /// <summary>
     /// Completes configuration and returns a handle that can be used to shut tracing down when no longer required.
     /// </summary>
     /// <param name="logger">The logger instance to emit traces through. Avoid using the shared <see cref="Log.Logger"/> as
-    /// the value here. To emit traces through the shared static logger, call <see cref="TraceToStaticLogger"/> instead.</param>
+    /// the value here. To emit traces through the shared static logger, call <see cref="TraceToSharedLogger"/> instead.</param>
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
     public IDisposable TraceTo(ILogger logger)
     {
@@ -62,7 +62,7 @@ public class TracingConfiguration
     /// will always emit traces through the current value of <see cref="Log.Logger"/>.
     /// </summary>
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
-    public IDisposable TraceToStaticLogger()
+    public IDisposable TraceToSharedLogger()
     {
         return EnableTracing(() => Log.Logger);
     }

--- a/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
+++ b/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
@@ -55,7 +55,7 @@ public class LoggerTracingExtensionsTests
             configuration.Sample.UsingActivityContext((ref ActivityCreationOptions<ActivityContext> _) => result);
         }
 
-        using var _ = tracingEnabled ? configuration.EnableTracing(log) : null;
+        using var _ = tracingEnabled ? configuration.TraceTo(log) : null;
         
         // This activity source is "outside" SerilogTracing and only exists to 
         var sourceName = Some.String();


### PR DESCRIPTION
Closes #36 

There's a footgun in the `EnableTracing()` API when it's either configured to emit traces through the shared `Log.Logger` and the application is using an independent `ILogger` or vice versa. This new API makes it much clearer where traces are intended to be sent. It also specifically calls out the issue of `TraceTo(Log.Logger)` as an anti-pattern, as nice and obvious as that would actually be to use.