### PR TITLE
Use templates as span names in OTLP

### DIFF
--- a/src/SerilogTracing.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OtlpEventBuilder.cs
+++ b/src/SerilogTracing.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OtlpEventBuilder.cs
@@ -36,7 +36,7 @@ static class OtlpEventBuilder
 
         ProcessProperties(logRecord.Attributes.Add, logEvent, includedData, out var scopeName);
         ProcessTimestamp(logRecord, logEvent);
-        ProcessMessage((message) => { logRecord.Body = new AnyValue {StringValue = message}; }, logEvent, includedData, formatProvider);
+        ProcessBody((message) => { logRecord.Body = new AnyValue {StringValue = message}; }, logEvent, includedData, formatProvider);
         ProcessLevel(logRecord, logEvent);
         ProcessException(logRecord.Attributes, logEvent);
         ProcessIncludedFields(logRecord, logEvent, includedData);
@@ -51,7 +51,7 @@ static class OtlpEventBuilder
         ProcessProperties(span.Attributes.Add, logEvent, includedData, out var scopeName);
         ProcessTimestamp(span, logEvent);
         ProcessStartTime(span, logEvent);
-        ProcessMessage((message) => { span.Name = message; }, logEvent, includedData, formatProvider);
+        ProcessName((message) => { span.Name = message; }, logEvent);
         ProcessLevel(span, logEvent);
         ProcessException(span.Attributes, logEvent);
         ProcessIncludedFields(span, logEvent, includedData);
@@ -60,7 +60,7 @@ static class OtlpEventBuilder
         return (span, scopeName);
     }
 
-    public static void ProcessMessage(Action<string> setBody, LogEvent logEvent, IncludedData includedFields, IFormatProvider? formatProvider)
+    public static void ProcessBody(Action<string> setBody, LogEvent logEvent, IncludedData includedFields, IFormatProvider? formatProvider)
     {
         if (!includedFields.HasFlag(IncludedData.TemplateBody))
         {
@@ -71,9 +71,17 @@ static class OtlpEventBuilder
                 setBody(renderedMessage);
             }
         }
-        else if (includedFields.HasFlag(IncludedData.TemplateBody) && logEvent.MessageTemplate.Text.Trim() != "")
+        else if (logEvent.MessageTemplate.Text.Trim() != "")
         {
             setBody(logEvent.MessageTemplate.Text);
+        }
+    }
+    
+    public static void ProcessName(Action<string> setName, LogEvent logEvent)
+    {
+        if (logEvent.MessageTemplate.Text.Trim() != "")
+        {
+            setName(logEvent.MessageTemplate.Text);
         }
     }
 

--- a/test/SerilogTracing.Sinks.OpenTelemetry.Tests/OtlpEventBuilderTests.cs
+++ b/test/SerilogTracing.Sinks.OpenTelemetry.Tests/OtlpEventBuilderTests.cs
@@ -45,16 +45,27 @@ public class OtlpEventBuilderTests
     {
         var logRecord = new LogRecord();
 
-        OtlpEventBuilder.ProcessMessage((message) => { logRecord.Body = new AnyValue {StringValue = message}; }, Some.SerilogEvent(messageTemplate: ""), OpenTelemetrySinkOptions.DefaultIncludedData, null);
+        OtlpEventBuilder.ProcessBody((message) => { logRecord.Body = new AnyValue {StringValue = message}; }, Some.SerilogEvent(messageTemplate: ""), OpenTelemetrySinkOptions.DefaultIncludedData, null);
         Assert.Null(logRecord.Body);
 
-        OtlpEventBuilder.ProcessMessage((message) => { logRecord.Body = new AnyValue {StringValue = message}; }, Some.SerilogEvent(messageTemplate: "\t\f "), OpenTelemetrySinkOptions.DefaultIncludedData, null);
+        OtlpEventBuilder.ProcessBody((message) => { logRecord.Body = new AnyValue {StringValue = message}; }, Some.SerilogEvent(messageTemplate: "\t\f "), OpenTelemetrySinkOptions.DefaultIncludedData, null);
         Assert.Null(logRecord.Body);
 
-        const string message = "log message";
-        OtlpEventBuilder.ProcessMessage((message) => { logRecord.Body = new AnyValue {StringValue = message}; }, Some.SerilogEvent(messageTemplate: message), OpenTelemetrySinkOptions.DefaultIncludedData, null);
+        const string template = "log message";
+        OtlpEventBuilder.ProcessBody((message) => { logRecord.Body = new AnyValue {StringValue = message}; }, Some.SerilogEvent(messageTemplate: template), OpenTelemetrySinkOptions.DefaultIncludedData, null);
         Assert.NotNull(logRecord.Body);
-        Assert.Equal(message, logRecord.Body.StringValue);
+        Assert.Equal(template, logRecord.Body.StringValue);
+    }
+    
+    [Fact]
+    public void TestProcessName()
+    {
+        var span = new Span();
+
+        const string template = "A {Template}";
+        OtlpEventBuilder.ProcessName((name) => { span.Name = name; }, Some.SerilogEvent(messageTemplate: template, properties: new LogEventProperty[] { new("Template", new ScalarValue("Value")) }));
+        Assert.NotNull(span.Name);
+        Assert.Equal(template, span.Name);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #46 

This PR doesn't make this decision configurable (yet). If we do decide to go down that path, we could add a flag to `IncludedData` either defaulted to opt-in for using the template as the name, or gave you an opt-out for it.