### PR TITLE
Leave Activity.Status as Unset on dispose

### DIFF
--- a/test/SerilogTracing.Tests/LoggerActivityTests.cs
+++ b/test/SerilogTracing.Tests/LoggerActivityTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Serilog;
 using Serilog.Events;
 using SerilogTracing.Tests.Support;
@@ -8,12 +9,13 @@ namespace SerilogTracing.Tests;
 public class LoggerActivityTests
 {
     [Theory]
-    [InlineData(LogEventLevel.Debug, null, LogEventLevel.Debug)]
-    [InlineData(LogEventLevel.Debug, LogEventLevel.Debug, LogEventLevel.Debug)]
-    [InlineData(LogEventLevel.Information, null, LogEventLevel.Information)]
-    [InlineData(LogEventLevel.Information, LogEventLevel.Warning, LogEventLevel.Warning)]
-    [InlineData(LogEventLevel.Information, LogEventLevel.Debug, LogEventLevel.Information)]
-    public void ExpectedCompletionLevelIsUsed(LogEventLevel initialLevel, LogEventLevel? completionLevel, LogEventLevel expected)
+    [InlineData(LogEventLevel.Debug, null, ActivityStatusCode.Ok, LogEventLevel.Debug)]
+    [InlineData(LogEventLevel.Debug, LogEventLevel.Debug, ActivityStatusCode.Ok, LogEventLevel.Debug)]
+    [InlineData(LogEventLevel.Information, null, ActivityStatusCode.Ok, LogEventLevel.Information)]
+    [InlineData(LogEventLevel.Information, LogEventLevel.Warning, ActivityStatusCode.Ok, LogEventLevel.Warning)]
+    [InlineData(LogEventLevel.Information, LogEventLevel.Debug, ActivityStatusCode.Ok, LogEventLevel.Information)]
+    [InlineData(LogEventLevel.Information, LogEventLevel.Error, ActivityStatusCode.Error, LogEventLevel.Error)]
+    public void ExpectedCompletionLevelIsUsed(LogEventLevel initialLevel, LogEventLevel? completionLevel, ActivityStatusCode expectedStatusCode, LogEventLevel expectedLevel)
     {
         var sink = new CollectingSink();
 
@@ -29,6 +31,26 @@ public class LoggerActivityTests
         loggerActivity.Complete(completionLevel);
 
         var span = sink.SingleEvent;
-        Assert.Equal(expected, span.Level);
+        Assert.Equal(expectedLevel, span.Level);
+        Assert.Equal(expectedStatusCode, activity.Status);
+    }
+    
+    [Fact]
+    public void ActivityStatusIsLeftUnsetOnDispose()
+    {
+        var sink = new CollectingSink();
+
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Is(LevelAlias.Minimum)
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        using var activity = Some.Activity();
+        activity.Start();
+        
+        var loggerActivity = new LoggerActivity(logger, LogEventLevel.Information, activity, MessageTemplate.Empty, []);
+        loggerActivity.Dispose();
+
+        Assert.Equal(ActivityStatusCode.Unset, activity.Status);
     }
 }


### PR DESCRIPTION
Closes #42 

If a `LoggerActivity` is disposed without completing then we'll leave the status of that activity as unset, instead of setting it to `Ok`. This makes it possible to distinguish activities that were intentionally completed from those that were disposed outside of regular control flow.