### PR TITLE
Add support for configuring the minimum level of external activities

### DIFF
--- a/example/Example.WeatherService/Program.cs
+++ b/example/Example.WeatherService/Program.cs
@@ -1,5 +1,4 @@
 using Serilog;
-using Serilog.Events;
 using Serilog.Templates.Themes;
 using SerilogTracing;
 using SerilogTracing.Expressions;

--- a/example/Example.WeatherService/Program.cs
+++ b/example/Example.WeatherService/Program.cs
@@ -1,4 +1,5 @@
 using Serilog;
+using Serilog.Events;
 using Serilog.Templates.Themes;
 using SerilogTracing;
 using SerilogTracing.Expressions;

--- a/src/SerilogTracing/Configuration/TracingInitialLevelConfiguration.cs
+++ b/src/SerilogTracing/Configuration/TracingInitialLevelConfiguration.cs
@@ -1,0 +1,59 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+using SerilogTracing.Core;
+
+namespace SerilogTracing.Configuration;
+
+/// <summary>
+/// Controls initial level configuration.
+/// </summary>
+public class TracingInitialLevelConfiguration
+{
+    readonly TracingConfiguration _tracingConfiguration;
+    readonly Dictionary<string, LoggingLevelSwitch> _overrides = new();
+    LogEventLevel _initialLevel = LogEventLevel.Information;
+
+    internal LevelOverrideMap GetOverrideMap() => new LevelOverrideMap(_overrides, _initialLevel, null);
+    
+    internal TracingInitialLevelConfiguration(TracingConfiguration tracingConfiguration)
+    {
+        _tracingConfiguration = tracingConfiguration;
+    }
+
+    /// <summary>
+    /// Sets the initial level that will be assigned to externally created activities.
+    /// </summary>
+    /// <param name="level">The initial level to set.</param>
+    public TracingConfiguration Is(LogEventLevel level)
+    {
+        _initialLevel = level;
+        return _tracingConfiguration;
+    }
+
+    /// <summary>
+    /// Override the initial level for activities from a specific <see cref="System.Diagnostics.ActivitySource"/>.
+    /// </summary>
+    /// <param name="activitySourceName">
+    /// The (partial) name of the <see cref="System.Diagnostics.ActivitySource"/> to override for. Prefixes are assumed
+    /// to be namespace sub-paths, such as <code>Microsoft</code> in <code>Microsoft.AspNetCore</code>.
+    /// </param>
+    /// <param name="levelSwitch">The initial level to set.</param>
+    public TracingConfiguration Override(string activitySourceName, LoggingLevelSwitch levelSwitch)
+    {
+        _overrides[activitySourceName] = levelSwitch;
+        return _tracingConfiguration;
+    }
+    
+    /// <summary>
+    /// Override the initial level for activities from a specific <see cref="System.Diagnostics.ActivitySource"/>.
+    /// </summary>
+    /// <param name="activitySourceName">
+    /// The (partial) name of the <see cref="System.Diagnostics.ActivitySource"/> to override for. Prefixes are assumed
+    /// to be namespace sub-paths, such as <code>Microsoft</code> in <code>Microsoft.AspNetCore</code>.
+    /// </param>
+    /// <param name="level">The initial level to set.</param>
+    public TracingConfiguration Override(string activitySourceName, LogEventLevel level)
+    {
+        return Override(activitySourceName, new LoggingLevelSwitch(level));
+    }
+}

--- a/src/SerilogTracing/Configuration/TracingSamplingConfiguration.cs
+++ b/src/SerilogTracing/Configuration/TracingSamplingConfiguration.cs
@@ -10,33 +10,27 @@ public class TracingSamplingConfiguration
     readonly TracingConfiguration _tracingConfiguration;
     SampleActivity<ActivityContext>? _sample;
     SampleActivity<string>? _sampleUsingParentId;
+    
+    internal SampleActivity<ActivityContext>? ActivityContext => _sample;
+    internal SampleActivity<string>? ParentId => _sampleUsingParentId;
 
     internal TracingSamplingConfiguration(TracingConfiguration tracingConfiguration)
     {
         _tracingConfiguration = tracingConfiguration;
     }
 
-    internal void ConfigureSampling(ActivityListener listener)
-    {
-        if (_sample is null && _sampleUsingParentId is null)
-        {
-            listener.Sample = delegate { return ActivitySamplingResult.AllData; };
-            return;
-        }
-
-        listener.Sample = _sample;
-        listener.SampleUsingParentId = _sampleUsingParentId;
-    }
-
     /// <summary>
-    /// Set the sampling level for the listener. The <see cref="ActivityContext"/> supplied to
+    /// Set the sampling level for the listener. The <see cref="System.Diagnostics.ActivityContext"/> supplied to
     /// the callback will contain the current trace id, and if the activity has a known parent
     /// a non-default span id identifying the parent.
     /// </summary>
     /// <param name="sample">A callback providing the sampling level for a particular activity.</param>
     /// <returns>The current instance, to enable method chaining.</returns>
-    /// <remarks>If the method is called multiple times, the last sampling callback to be
-    /// specified will be used.</remarks>
+    /// <remarks>
+    /// If the method is called multiple times, the last sampling callback to be specified will be used.
+    /// This sampler will only run on activities that pass the <see cref="Serilog.ILogger.IsEnabled"/> filter
+    /// on the destination logger.
+    /// </remarks>
     /// <seealso cref="ActivityListener.Sample"/>
     public TracingConfiguration UsingActivityContext(SampleActivity<ActivityContext> sample)
     {
@@ -50,8 +44,11 @@ public class TracingSamplingConfiguration
     /// </summary>
     /// <param name="sample">A callback providing the sampling level for a particular activity.</param>
     /// <returns>The current instance, to enable method chaining.</returns>
-    /// <remarks>If the method is called multiple times, the last sampling callback to be
-    /// specified will be used.</remarks>
+    /// <remarks>
+    /// If the method is called multiple times, the last sampling callback to be specified will be used.
+    /// This sampler will only run on activities that pass the <see cref="Serilog.ILogger.IsEnabled"/> filter
+    /// on the destination logger.
+    /// </remarks>
     /// <seealso cref="ActivityListener.SampleUsingParentId"/>
     public TracingConfiguration UsingParentId(SampleActivity<string> sample)
     {

--- a/src/SerilogTracing/Core/LevelOverrideMap.cs
+++ b/src/SerilogTracing/Core/LevelOverrideMap.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2016-2020 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Core;
+using Serilog.Events;
+
+namespace SerilogTracing.Core;
+
+class LevelOverrideMap
+{
+    readonly LogEventLevel _defaultMinimumLevel;
+    readonly LoggingLevelSwitch? _defaultLevelSwitch;
+
+    readonly struct LevelOverride
+    {
+        public LevelOverride(string context, LoggingLevelSwitch levelSwitch)
+        {
+            Context = context;
+            LevelSwitch = levelSwitch;
+        }
+
+        public string Context { get; }
+
+        public LoggingLevelSwitch LevelSwitch { get; }
+    }
+
+    // There are two possible strategies to apply:
+    //   1. Keep some bookkeeping data to consult when a new context is encountered, and a concurrent dictionary
+    //        for exact matching ~ O(1), but slow and requires fences/locks; or,
+    //   2. O(n) search over the raw configuration data every time (fast for small sets of overrides).
+    // This implementation assumes there will only be a few overrides in each application, so chooses (2). This
+    // is an assumption that's up for debate.
+    readonly LevelOverride[] _overrides;
+
+    public LevelOverrideMap(
+        IDictionary<string, LoggingLevelSwitch> overrides,
+        LogEventLevel defaultMinimumLevel,
+        LoggingLevelSwitch? defaultLevelSwitch)
+    {
+        _defaultLevelSwitch = defaultLevelSwitch;
+        _defaultMinimumLevel = defaultLevelSwitch != null ? LevelAlias.Minimum : defaultMinimumLevel;
+
+        // Descending order means that if we have a match, we're sure about it being the most specific.
+        _overrides = overrides
+            .OrderByDescending(o => o.Key)
+            .Select(o => new LevelOverride(o.Key, o.Value))
+            .ToArray();
+    }
+
+    public void GetEffectiveLevel(
+        string context,
+        out LogEventLevel minimumLevel,
+        out LoggingLevelSwitch? levelSwitch)
+    {
+        foreach (var levelOverride in _overrides)
+        {
+            if (context.StartsWith(levelOverride.Context) &&
+                (context.Length == levelOverride.Context.Length || context[levelOverride.Context.Length] == '.'))
+            {
+                minimumLevel = LevelAlias.Minimum;
+                levelSwitch = levelOverride.LevelSwitch;
+                return;
+            }
+        }
+
+        minimumLevel = _defaultMinimumLevel;
+        levelSwitch = _defaultLevelSwitch;
+    }
+}

--- a/src/SerilogTracing/Interop/ActivityConvert.cs
+++ b/src/SerilogTracing/Interop/ActivityConvert.cs
@@ -9,7 +9,7 @@ namespace SerilogTracing.Interop;
 
 static class ActivityConvert
 {
-    internal static LogEvent ActivityToLogEvent(ILogger logger, Activity activity)
+    internal static LogEvent ActivityToLogEvent(ILogger logger, Activity activity, LogEventLevel level)
     {
         var start = activity.StartTimeUtc;
         
@@ -17,7 +17,6 @@ static class ActivityConvert
         // be recorded correctly and this is what machine-readable outputs will see.
         var end = new DateTimeOffset(start + activity.Duration).ToLocalTime();
         
-        var level = activity.Status == ActivityStatusCode.Error ? LogEventLevel.Error : LogEventLevel.Information;
         ActivityInstrumentation.TryGetMessageTemplateOverride(activity, out var messageTemplate);
         var template = messageTemplate ?? new MessageTemplate(new[] { new TextToken(activity.DisplayName) });
         ActivityInstrumentation.TryGetException(activity, out var exception);

--- a/src/SerilogTracing/LoggerActivity.cs
+++ b/src/SerilogTracing/LoggerActivity.cs
@@ -125,6 +125,13 @@ public sealed class LoggerActivity : IDisposable
 
         // This property can be removed once we can rely on the existence of Activity.IsStopped.
         IsComplete = true;
+        
+        if (Activity!.Recorded)
+        {
+            Activity.Stop();
+            return;
+        }
+        
         var end = DateTimeOffset.Now;
 
         var completionLevel = DefaultCompletionLevel;

--- a/src/SerilogTracing/LoggerActivity.cs
+++ b/src/SerilogTracing/LoggerActivity.cs
@@ -122,11 +122,13 @@ public sealed class LoggerActivity : IDisposable
         {
             return;
         }
+        
+        // `Activity` is guaranteed to be non-null here thanks to `!IsSuppressed`
 
         // This property can be removed once we can rely on the existence of Activity.IsStopped.
         IsComplete = true;
         
-        if (Activity!.Recorded)
+        if (!Activity!.Recorded)
         {
             Activity.Stop();
             return;

--- a/src/SerilogTracing/TracingConfiguration.cs
+++ b/src/SerilogTracing/TracingConfiguration.cs
@@ -4,8 +4,10 @@ using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
 using SerilogTracing.Configuration;
+using SerilogTracing.Core;
 using SerilogTracing.Instrumentation;
 using SerilogTracing.Interop;
+using Constants = Serilog.Core.Constants;
 
 namespace SerilogTracing;
 
@@ -15,24 +17,30 @@ namespace SerilogTracing;
 public class TracingConfiguration
 {
     /// <summary>
-    /// Construct a new <see cref="TracingConfiguration"/>.
+    /// Construct a new <see cref="TracingConfiguration" />.
     /// </summary>
     public TracingConfiguration()
     {
         Instrument = new TracingInstrumentationConfiguration(this);
         Sample = new TracingSamplingConfiguration(this);
+        InitialLevel = new TracingInitialLevelConfiguration(this);
     }
 
     /// <summary>
     /// Configures instrumentation of <see cref="Activity">activities</see>.
     /// </summary>
     public TracingInstrumentationConfiguration Instrument { get; }
-    
+
     /// <summary>
     /// Configures sampling.
     /// </summary>
     public TracingSamplingConfiguration Sample { get; }
-    
+
+    /// <summary>
+    /// Configures the initial level assigned to externally created activities.
+    /// </summary>
+    public TracingInitialLevelConfiguration InitialLevel { get; }
+
     /// <summary>
     /// Completes configuration and returns a handle that can be used to shut tracing down when no longer required.
     /// </summary>
@@ -46,8 +54,10 @@ public class TracingConfiguration
     /// <summary>
     /// Completes configuration and returns a handle that can be used to shut tracing down when no longer required.
     /// </summary>
-    /// <param name="logger">The logger instance to emit traces through. Avoid using the shared <see cref="Log.Logger"/> as
-    /// the value here. To emit traces through the shared static logger, call <see cref="TraceToSharedLogger"/> instead.</param>
+    /// <param name="logger">
+    /// The logger instance to emit traces through. Avoid using the shared <see cref="Log.Logger" /> as
+    /// the value here. To emit traces through the shared static logger, call <see cref="TraceToSharedLogger" /> instead.
+    /// </param>
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
     public IDisposable TraceTo(ILogger logger)
     {
@@ -56,10 +66,9 @@ public class TracingConfiguration
 
     /// <summary>
     /// Completes configuration and returns a handle that can be used to shut tracing down when no longer required.
-    ///
     /// This method is not equivalent to <code>TraceTo(Log.Logger)</code>. The former will emit traces through whatever the
-    /// value of <see cref="Log.Logger"/> happened to be at the time <see cref="TraceTo"/> was called. This method
-    /// will always emit traces through the current value of <see cref="Log.Logger"/>.
+    /// value of <see cref="Log.Logger" /> happened to be at the time <see cref="TraceTo" /> was called. This method
+    /// will always emit traces through the current value of <see cref="Log.Logger" />.
     /// </summary>
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
     public IDisposable TraceToSharedLogger()
@@ -69,39 +78,78 @@ public class TracingConfiguration
 
     IDisposable EnableTracing(Func<ILogger> logger)
     {
-        var instrumentors = Instrument.GetInstrumentors().ToArray();
-        var activityListener = new ActivityListener();
-        var diagnosticListenerSubscription = DiagnosticListener.AllListeners.Subscribe(new DiagnosticListenerObserver(instrumentors));
-        var disposeProxy = new DisposeProxy(diagnosticListenerSubscription, activityListener);
-        
         ILogger GetLogger(string name)
         {
             var instance = logger();
-            return !string.IsNullOrWhiteSpace(name) ? instance.ForContext(Constants.SourceContextPropertyName, name) : instance;
+            return !string.IsNullOrWhiteSpace(name)
+                ? instance.ForContext(Constants.SourceContextPropertyName, name)
+                : instance;
         }
 
-        Sample.ConfigureSampling(activityListener);
-        
-        // Note, this will not be reevaluated if the minimum level dynamically changes.
-        activityListener.ShouldListenTo = source => source.Name == Core.Constants.SerilogActivitySourceName || GetLogger(source.Name).IsEnabled(LogEventLevel.Fatal);
+        var activityListener = new ActivityListener();
+        var disposeProxy = new DisposeProxy(activityListener,
+            DiagnosticListener.AllListeners.Subscribe(
+                new DiagnosticListenerObserver(Instrument.GetInstrumentors().ToArray())));
+
+        var levelMap = InitialLevel.GetOverrideMap();
+
+        // NOTE: We may want a config setting to only listen to specific sources
+        activityListener.ShouldListenTo = _ => true;
+
+        var sample = Sample.ActivityContext;
+        var usingParentId = Sample.ParentId;
+        activityListener.Sample = (ref ActivityCreationOptions<ActivityContext> activity) =>
+        {
+            if (!GetLogger(activity.Source.Name)
+                    .IsEnabled(GetInitialLevel(levelMap, activity.Source.Name)))
+                return ActivitySamplingResult.None;
+
+            return sample?.Invoke(ref activity) ?? ActivitySamplingResult.AllData;
+        };
+        activityListener.SampleUsingParentId = (ref ActivityCreationOptions<string> activity) =>
+        {
+            if (!GetLogger(activity.Source.Name)
+                    .IsEnabled(GetInitialLevel(levelMap, activity.Source.Name)))
+                return ActivitySamplingResult.None;
+
+            return usingParentId?.Invoke(ref activity) ?? ActivitySamplingResult.AllData;
+        };
 
         activityListener.ActivityStopped += activity =>
         {
+            if (!activity.Recorded) return;
+            
             if (ActivityInstrumentation.HasAttachedLoggerActivity(activity))
                 return; // `LoggerActivity` completion writes these to the activity-specific logger.
 
             var activityLogger = GetLogger(activity.Source.Name);
 
-            var level = ActivityInstrumentation.GetCompletionLevel(activity);
+            var level = GetCompletionLevel(levelMap, activity);
+
             if (!activityLogger.IsEnabled(level))
                 return;
 
-            activityLogger.Write(ActivityConvert.ActivityToLogEvent(activityLogger, activity));
+            activityLogger.Write(ActivityConvert.ActivityToLogEvent(activityLogger, activity, level));
         };
-        
+
         ActivitySource.AddActivityListener(activityListener);
 
         return disposeProxy;
+    }
+
+    static LogEventLevel GetInitialLevel(LevelOverrideMap levelMap, string activitySourceName)
+    {
+        levelMap.GetEffectiveLevel(activitySourceName, out var initialLevel, out var overrideLevel);
+
+        return overrideLevel?.MinimumLevel ?? initialLevel;
+    }
+
+    static LogEventLevel GetCompletionLevel(LevelOverrideMap levelMap, Activity activity)
+    {
+        var level = ActivityInstrumentation.GetCompletionLevel(activity);
+        var overrideLevel = GetInitialLevel(levelMap, activity.Source.Name);
+
+        return overrideLevel > level ? overrideLevel : level;
     }
 
     sealed class DisposeProxy(params IDisposable[] disposables) : IDisposable
@@ -109,7 +157,6 @@ public class TracingConfiguration
         public void Dispose()
         {
             foreach (var disposable in disposables)
-            {
                 try
                 {
                     disposable.Dispose();
@@ -118,7 +165,6 @@ public class TracingConfiguration
                 {
                     SelfLog.WriteLine("TracingLogger: exception in dispose" + Environment.NewLine + ex);
                 }
-            }
         }
     }
 }

--- a/test/SerilogTracing.Tests/LoggerActivityTests.cs
+++ b/test/SerilogTracing.Tests/LoggerActivityTests.cs
@@ -25,6 +25,7 @@ public class LoggerActivityTests
             .CreateLogger();
 
         using var activity = Some.Activity();
+        activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
         activity.Start();
         
         var loggerActivity = new LoggerActivity(logger, initialLevel, activity, MessageTemplate.Empty, []);
@@ -81,6 +82,7 @@ public class LoggerActivityTests
             .CreateLogger();
         
         using var activity = Some.Activity();
+        activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
         activity.IsAllDataRequested = false;
         activity.Start();
 

--- a/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
+++ b/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
@@ -64,9 +64,10 @@ public class LoggerTracingExtensionsTests
         using var parent = source.StartActivity(Some.String());
         
         Assert.NotNull(parent);
+        parent.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
+        
         Assert.NotEqual(default(ActivityTraceId).ToHexString(), parent.TraceId.ToHexString());
         Assert.NotEqual(default(ActivitySpanId).ToHexString(), parent.SpanId.ToHexString());
-
         
         var activity = log
             .ForContext(Serilog.Core.Constants.SourceContextPropertyName, activitySourceContext)


### PR DESCRIPTION
Closes #55 
Closes #31 
Closes #44 

This is a first cut at initial level configuration and its use in activity sampling. For #44, the solution is somewhat roundabout. If you set the initial level for a particular activity source below the minimum then you won't see activities from it.

Instead of using `Activity.OperationName`, we use `Activity.Source.Name` which is conventionally a namespace-like identifier and is less prone to change.

This PR adds support for configuring the initial level for activities created outside of `ILogger.StartActivity`, and using that initial level when sampling activities. This allows us to control trace granularity using the existing level filtering in Serilog.

Note that ASP.NET Core will always create an activity if there are any diagnostic listeners registered, even if sampling suggests no activity should be created. This is a behavioral oddity in ASP.NET Core, but one that we already have to deal with given other listeners may want traces that SerilogTracing doesn't.