### PR TITLE
Set activity status on HTTP client and server spans

### DIFF
--- a/serilog-tracing.sln.DotSettings
+++ b/serilog-tracing.sln.DotSettings
@@ -1,4 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enrichers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Evented/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Instrumentor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Instrumentors/@EntryIndexedValue">True</s:Boolean>

--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
@@ -59,6 +59,11 @@ sealed class HttpRequestInActivityInstrumentor: IActivityInstrumentor
                 
                 ActivityInstrumentation.SetLogEventProperties(activity, _getResponseProperties(stop.Response).ToArray());
 
+                if (stop.Response.StatusCode >= 500)
+                {
+                    activity.SetStatus(ActivityStatusCode.Error);
+                }
+
                 break;
         }
     }

--- a/src/SerilogTracing/Configuration/TracingSamplingConfiguration.cs
+++ b/src/SerilogTracing/Configuration/TracingSamplingConfiguration.cs
@@ -9,10 +9,8 @@ public class TracingSamplingConfiguration
 {
     readonly TracingConfiguration _tracingConfiguration;
     SampleActivity<ActivityContext>? _sample;
-    SampleActivity<string>? _sampleUsingParentId;
     
     internal SampleActivity<ActivityContext>? ActivityContext => _sample;
-    internal SampleActivity<string>? ParentId => _sampleUsingParentId;
 
     internal TracingSamplingConfiguration(TracingConfiguration tracingConfiguration)
     {
@@ -32,27 +30,9 @@ public class TracingSamplingConfiguration
     /// on the destination logger.
     /// </remarks>
     /// <seealso cref="ActivityListener.Sample"/>
-    public TracingConfiguration UsingActivityContext(SampleActivity<ActivityContext> sample)
+    public TracingConfiguration Using(SampleActivity<ActivityContext> sample)
     {
         _sample = sample;
-        return _tracingConfiguration;
-    }
-
-    /// <summary>
-    /// Set the sampling level for the listener. The string supplied to
-    /// the callback will contain the current trace id.
-    /// </summary>
-    /// <param name="sample">A callback providing the sampling level for a particular activity.</param>
-    /// <returns>The current instance, to enable method chaining.</returns>
-    /// <remarks>
-    /// If the method is called multiple times, the last sampling callback to be specified will be used.
-    /// This sampler will only run on activities that pass the <see cref="Serilog.ILogger.IsEnabled"/> filter
-    /// on the destination logger.
-    /// </remarks>
-    /// <seealso cref="ActivityListener.SampleUsingParentId"/>
-    public TracingConfiguration UsingParentId(SampleActivity<string> sample)
-    {
-        _sampleUsingParentId = sample;
         return _tracingConfiguration;
     }
 }

--- a/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentor.cs
@@ -64,7 +64,7 @@ sealed class HttpRequestOutActivityInstrumentor: IActivityInstrumentor
                 }
 
                 var statusCode = response != null ? (int?)response.StatusCode : null;
-                activity.AddTag("StatusCode", statusCode);
+                ActivityInstrumentation.SetLogEventProperty(activity, new LogEventProperty("StatusCode", new ScalarValue(statusCode)));
 
                 if (activity.Status == ActivityStatusCode.Unset)
                 {

--- a/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentor.cs
@@ -62,14 +62,21 @@ sealed class HttpRequestOutActivityInstrumentor: IActivityInstrumentor
                 {
                     return;
                 }
-                
-                activity.AddTag("StatusCode", response != null ? (int)response.StatusCode : null);
 
-                if (activity.Status == ActivityStatusCode.Unset &&
-                    _requestTaskStatusAccessor.TryGetValue(eventArgs, out var requestTaskStatus))
+                var statusCode = response != null ? (int?)response.StatusCode : null;
+                activity.AddTag("StatusCode", statusCode);
+
+                if (activity.Status == ActivityStatusCode.Unset)
                 {
-                    if (requestTaskStatus == TaskStatus.Faulted || response is { IsSuccessStatusCode: false })
+                    if (statusCode >= 400)
+                    {
                         activity.SetStatus(ActivityStatusCode.Error);
+                    }
+                    else if (_requestTaskStatusAccessor.TryGetValue(eventArgs, out var requestTaskStatus))
+                    {
+                        if (requestTaskStatus == TaskStatus.Faulted || response is { IsSuccessStatusCode: false })
+                            activity.SetStatus(ActivityStatusCode.Error);
+                    }
                 }
 
                 break;

--- a/src/SerilogTracing/TracingConfiguration.cs
+++ b/src/SerilogTracing/TracingConfiguration.cs
@@ -98,7 +98,6 @@ public class TracingConfiguration
         activityListener.ShouldListenTo = _ => true;
 
         var sample = Sample.ActivityContext;
-        var usingParentId = Sample.ParentId;
         activityListener.Sample = (ref ActivityCreationOptions<ActivityContext> activity) =>
         {
             if (!GetLogger(activity.Source.Name)
@@ -107,21 +106,6 @@ public class TracingConfiguration
 
             return sample?.Invoke(ref activity) ?? ActivitySamplingResult.AllData;
         };
-
-        // Only set this listener if the user supplied a parent id based sampler,
-        // or if they didn't supply a context based one. It's treated preferentially, so if set
-        // then the context based sampler will be ignored.
-        if (usingParentId != null || sample == null)
-        {
-            activityListener.SampleUsingParentId = (ref ActivityCreationOptions<string> activity) =>
-            {
-                if (!GetLogger(activity.Source.Name)
-                        .IsEnabled(GetInitialLevel(levelMap, activity.Source.Name)))
-                    return ActivitySamplingResult.None;
-
-                return usingParentId?.Invoke(ref activity) ?? ActivitySamplingResult.AllData;
-            };
-        }
 
         activityListener.ActivityStopped += activity =>
         {

--- a/src/SerilogTracing/TracingConfiguration.cs
+++ b/src/SerilogTracing/TracingConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using Serilog;
-using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
 using SerilogTracing.Configuration;

--- a/test/SerilogTracing.Tests/ActivityInstrumentationTests.cs
+++ b/test/SerilogTracing.Tests/ActivityInstrumentationTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace SerilogTracing.Tests;
 
+[Collection("Shared")]
 public class ActivityInstrumentationTests
 {
     [Fact]
@@ -15,7 +16,7 @@ public class ActivityInstrumentationTests
         var templateA = new MessageTemplateParser().Parse("{Template} A");
         var templateB = new MessageTemplateParser().Parse("{Template} B");
 
-        var activity = Some.Activity();
+        using var activity = Some.Activity();
         
         Assert.False(ActivityInstrumentation.TryGetMessageTemplateOverride(activity, out _));
         
@@ -33,7 +34,7 @@ public class ActivityInstrumentationTests
     [Fact]
     public void GetSetLogEventProperties()
     {
-        var activity = Some.Activity();
+        using var activity = Some.Activity();
 
         var a = Some.Boolean();
         var b = Some.Integer();
@@ -68,17 +69,21 @@ public class ActivityInstrumentationTests
     }
 
     [Fact]
-    public void GetSetException()
+    public void TrySetExceptionDoesNotOverrideExistingEvent()
     {
-        var activity = Some.Activity();
+        using var activity = Some.Activity();
 
         activity.AddEvent(new ActivityEvent("exception"));
         
         Assert.True(ActivityInstrumentation.TryGetException(activity, out _));
         
         Assert.False(ActivityInstrumentation.TrySetException(activity, new Exception("Test Error")));
+    }
 
-        activity = Some.Activity();
+    [Fact]
+    public void GetAndSetExceptionIsRoundTripped()
+    {
+        using var activity = Some.Activity();
         
         Assert.False(ActivityInstrumentation.TryGetException(activity, out _));
         

--- a/test/SerilogTracing.Tests/ExternalActivityTests.cs
+++ b/test/SerilogTracing.Tests/ExternalActivityTests.cs
@@ -12,7 +12,7 @@ public class ExternalActivityTests
     [Fact]
     public void ExternalActivitiesAreEmitted()
     {
-        var source = new ActivitySource($"{typeof(ExternalActivityTests).FullName}.${nameof(ExternalActivitiesAreEmitted)}");
+        using var source = Some.ActivitySource();
         
         var sink = new CollectingSink();
 

--- a/test/SerilogTracing.Tests/ExternalActivityTests.cs
+++ b/test/SerilogTracing.Tests/ExternalActivityTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace SerilogTracing.Tests;
 
+[Collection("Shared")]
 public class ExternalActivityTests
 {
     [Fact]
@@ -20,9 +21,9 @@ public class ExternalActivityTests
             .WriteTo.Sink(sink)
             .CreateLogger();
 
-        new TracingConfiguration().TraceTo(logger);
+        using var _ = new TracingConfiguration().TraceTo(logger);
 
-        var activity = source.StartActivity()!;
+        using var activity = source.StartActivity()!;
         activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
         activity.Stop();
         
@@ -42,11 +43,11 @@ public class ExternalActivityTests
             .WriteTo.Sink(sink)
             .CreateLogger();
 
-        new TracingConfiguration()
+        using var _ = new TracingConfiguration()
             .InitialLevel.Is(LogEventLevel.Debug)
             .TraceTo(logger);
 
-        var activity = source.StartActivity()!;
+        using var activity = source.StartActivity()!;
         activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
         activity.Stop();
         
@@ -67,11 +68,11 @@ public class ExternalActivityTests
             .WriteTo.Sink(sink)
             .CreateLogger();
 
-        new TracingConfiguration()
+        using var _ = new TracingConfiguration()
             .InitialLevel.Is(initialLevel)
             .TraceTo(logger);
 
-        var activity = source.StartActivity()!;
+        using var activity = source.StartActivity()!;
         activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
         activity.SetStatus(ActivityStatusCode.Error);
         activity.Stop();
@@ -91,11 +92,11 @@ public class ExternalActivityTests
             .WriteTo.Sink(sink)
             .CreateLogger();
 
-        new TracingConfiguration()
+        using var _ = new TracingConfiguration()
             .InitialLevel.Override(typeof(ExternalActivityTests).FullName!, LogEventLevel.Debug)
             .TraceTo(logger);
 
-        var activity = source.StartActivity()!;
+        using var activity = source.StartActivity()!;
         activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
         activity.Stop();
         
@@ -105,7 +106,7 @@ public class ExternalActivityTests
     [Fact]
     public void ExternalActivitiesSampleInitialLevel()
     {
-        var source = new ActivitySource($"{typeof(ExternalActivityTests).FullName}.${nameof(ExternalActivitiesSampleInitialLevel)}");
+        using var source = Some.ActivitySource();
         
         var sink = new CollectingSink();
 
@@ -114,14 +115,11 @@ public class ExternalActivityTests
             .WriteTo.Sink(sink)
             .CreateLogger();
 
-        new TracingConfiguration()
+        using var _ = new TracingConfiguration()
             .InitialLevel.Is(LogEventLevel.Debug)
             .TraceTo(logger);
 
-        var activity = source.StartActivity()!;
-        activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
-        activity.Stop();
-        
-        Assert.Empty(sink.Events);
+        using var activity = source.StartActivity();
+        Assert.Null(activity);
     }
 }

--- a/test/SerilogTracing.Tests/Instrumentation/DiagnosticEventObserverTests.cs
+++ b/test/SerilogTracing.Tests/Instrumentation/DiagnosticEventObserverTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace SerilogTracing.Tests.Instrumentation;
 
+[Collection("Shared")]
 public class DiagnosticEventObserverTests
 {
     [Fact]

--- a/test/SerilogTracing.Tests/Instrumentation/DirectDiagnosticEventObserverTests.cs
+++ b/test/SerilogTracing.Tests/Instrumentation/DirectDiagnosticEventObserverTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace SerilogTracing.Tests.Instrumentation;
 
+[Collection("Shared")]
 public class DirectDiagnosticEventObserverTests
 {
     [Fact]

--- a/test/SerilogTracing.Tests/LoggerActivityTests.cs
+++ b/test/SerilogTracing.Tests/LoggerActivityTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace SerilogTracing.Tests;
 
+[Collection("Shared")]
 public class LoggerActivityTests
 {
     [Theory]

--- a/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
+++ b/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
@@ -51,7 +51,7 @@ public class LoggerTracingExtensionsTests
         if (includedInSample is { } always)
         {
             var result = always ? ActivitySamplingResult.AllData : ActivitySamplingResult.None;
-            configuration.Sample.UsingParentId((ref ActivityCreationOptions<string> _) => result);
+            configuration.Sample.Using((ref ActivityCreationOptions<ActivityContext> _) => result);
         }
 
         using var _ = tracingEnabled ? configuration.TraceTo(log) : null;

--- a/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
+++ b/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace SerilogTracing.Tests;
 
+[Collection("Shared")]
 public class LoggerTracingExtensionsTests
 {
     static LoggerTracingExtensionsTests()
@@ -51,15 +52,13 @@ public class LoggerTracingExtensionsTests
         {
             var result = always ? ActivitySamplingResult.AllData : ActivitySamplingResult.None;
             configuration.Sample.UsingParentId((ref ActivityCreationOptions<string> _) => result);
-            configuration.Sample.UsingActivityContext((ref ActivityCreationOptions<ActivityContext> _) => result);
         }
 
         using var _ = tracingEnabled ? configuration.TraceTo(log) : null;
         
         // This activity source is "outside" SerilogTracing and only exists to 
-        var sourceName = Some.String();
-        using var listener = CreateAlwaysOnListenerFor(sourceName);
-        using var source = new ActivitySource(sourceName);
+        using var source = Some.ActivitySource();
+        using var listener = Some.AlwaysOnListenerFor(source.Name);
         using var parent = source.StartActivity(Some.String());
         
         Assert.NotNull(parent);
@@ -89,15 +88,5 @@ public class LoggerTracingExtensionsTests
             Assert.Same(LoggerActivity.None, activity);
             Assert.Empty(sink.Events);
         }
-    }
-
-    static ActivityListener CreateAlwaysOnListenerFor(string sourceName)
-    {
-        var listener = new ActivityListener();
-        listener.ShouldListenTo = source => source.Name == sourceName;
-        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData;
-        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 }

--- a/test/SerilogTracing.Tests/SerilogTracing.Tests.csproj
+++ b/test/SerilogTracing.Tests/SerilogTracing.Tests.csproj
@@ -17,10 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\SerilogTracing.Expressions\SerilogTracing.Expressions.csproj" />
     <ProjectReference Include="..\..\src\SerilogTracing\SerilogTracing.csproj" />
   </ItemGroup>

--- a/test/SerilogTracing.Tests/Support/Some.cs
+++ b/test/SerilogTracing.Tests/Support/Some.cs
@@ -47,4 +47,19 @@ static class Some
 
         return logEvent;
     }
+
+    public static ActivitySource ActivitySource()
+    {
+        return new ActivitySource(String());
+    }
+
+    public static ActivityListener AlwaysOnListenerFor(string sourceName)
+    {
+        var listener = new ActivityListener();
+        listener.ShouldListenTo = source => source.Name == sourceName;
+        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData;
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
+        System.Diagnostics.ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
 }

--- a/test/SerilogTracing.Tests/Support/Some.cs
+++ b/test/SerilogTracing.Tests/Support/Some.cs
@@ -57,8 +57,7 @@ static class Some
     {
         var listener = new ActivityListener();
         listener.ShouldListenTo = source => source.Name == sourceName;
-        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData;
-        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> ctx) => ctx.Source.Name == sourceName ? ActivitySamplingResult.AllData : ActivitySamplingResult.None;
         System.Diagnostics.ActivitySource.AddActivityListener(listener);
         return listener;
     }

--- a/test/SerilogTracing.Tests/TracingConfigurationTests.cs
+++ b/test/SerilogTracing.Tests/TracingConfigurationTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace SerilogTracing.Tests;
 
+[Collection("Shared")]
 public class TracingConfigurationTests
 {
     [Fact]

--- a/test/SerilogTracing.Tests/TracingConfigurationTests.cs
+++ b/test/SerilogTracing.Tests/TracingConfigurationTests.cs
@@ -19,7 +19,6 @@ public class TracingConfigurationTests
         configuration.Instrument.WithDefaultInstrumentation(false);
         configuration.Instrument.HttpClientRequests();
 
-        configuration.Sample.UsingActivityContext((ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.None);
-        configuration.Sample.UsingParentId((ref ActivityCreationOptions<string> _) => ActivitySamplingResult.None);
+        configuration.Sample.Using((ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.None);
     }
 }

--- a/test/SerilogTracing.Tests/xunit.runner.json
+++ b/test/SerilogTracing.Tests/xunit.runner.json
@@ -1,4 +1,0 @@
-﻿{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeTestCollections": false
-}


### PR DESCRIPTION
On ASP.NET Core server spans, 500 and greater will mark the activity status as Error. On `HttpClient` spans, 400 and greater is an error.