### PR TITLE
A round of perf improvements

### DIFF
--- a/src/SerilogTracing/Instrumentation/ActivityInstrumentation.cs
+++ b/src/SerilogTracing/Instrumentation/ActivityInstrumentation.cs
@@ -82,7 +82,7 @@ public static class ActivityInstrumentation
         }
     }
 
-    static void SetLogEventProperty(Activity activity, LogEventProperty property, Dictionary<string, LogEventProperty> collection)
+    internal static void SetLogEventProperty(Activity activity, LogEventProperty property, Dictionary<string, LogEventProperty> collection)
     {
         activity.SetTag(property.Name, ToActivityTagValue(property.Value));
         collection[property.Name] = property;
@@ -93,19 +93,7 @@ public static class ActivityInstrumentation
         return propertyValue is ScalarValue sv ? sv.Value : propertyValue;
     }
 
-    /// <summary>
-    /// Get all <see cref="LogEventProperty">log event properties</see> set on the activity by <see cref="ActivityInstrumentation.SetLogEventProperty(Activity, LogEventProperty)"/>.
-    ///
-    /// This method won't include tags on the activity.
-    /// </summary>
-    /// <param name="activity">The activity containing the properties.</param>
-    /// <returns>A collection of properties set on the activity.</returns>
-    internal static IEnumerable<LogEventProperty> GetLogEventProperties(Activity activity)
-    {
-        return TryGetLogEventPropertyCollection(activity, out var existing) ? existing.Values : Enumerable.Empty<LogEventProperty>();
-    }
-    
-    static bool TryGetLogEventPropertyCollection(Activity activity, [NotNullWhen(true)] out Dictionary<string, LogEventProperty>? properties)
+    internal static bool TryGetLogEventPropertyCollection(Activity activity, [NotNullWhen(true)] out Dictionary<string, LogEventProperty>? properties)
     {
         if (activity.GetCustomProperty(Constants.LogEventPropertyCollectionName) is Dictionary<string, LogEventProperty> existing)
         {
@@ -215,6 +203,6 @@ public static class ActivityInstrumentation
 
     internal static bool IsDataSuppressed(Activity? activity)
     {
-        return activity is not {IsAllDataRequested: true} || IsSuppressed(activity);
+        return activity is not { IsAllDataRequested: true };
     }
 }

--- a/src/SerilogTracing/Instrumentation/DiagnosticListenerObserver.cs
+++ b/src/SerilogTracing/Instrumentation/DiagnosticListenerObserver.cs
@@ -31,7 +31,7 @@ sealed class DiagnosticListenerObserver : IObserver<DiagnosticListener>, IDispos
             {
                 observer = new DirectDiagnosticEventObserver(observer, direct);
             }
-                
+
             _subscriptions.Add(value.Subscribe(observer));
         }
     }

--- a/src/SerilogTracing/LoggerActivity.cs
+++ b/src/SerilogTracing/LoggerActivity.cs
@@ -83,7 +83,7 @@ public sealed class LoggerActivity : IDisposable
         
         if (Logger.BindProperty(propertyName, value, destructureObjects, out var property))
         {
-            ActivityInstrumentation.SetLogEventProperty(Activity!, property);
+            ActivityInstrumentation.SetLogEventProperty(Activity!, property, Properties);
         }
     }
     

--- a/src/SerilogTracing/SerilogTracing.csproj
+++ b/src/SerilogTracing/SerilogTracing.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <DefineConstants>$(DefineConstants);FEATURE_ACTIVITY_ISSTOPPED</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ACTIVITY_ISSTOPPED;FEATURE_ACTIVITY_STRUCTENUMERATORS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/SerilogTracing.Tests/ActivityInstrumentationTests.cs
+++ b/test/SerilogTracing.Tests/ActivityInstrumentationTests.cs
@@ -47,7 +47,8 @@ public class ActivityInstrumentationTests
         activity.SetTag("a", a);
         
         // Tags are not included in custom properties
-        Assert.Empty(ActivityInstrumentation.GetLogEventProperties(activity));
+        Assert.False(ActivityInstrumentation.TryGetLogEventPropertyCollection(activity, out var logEventProperties));
+        Assert.Null(logEventProperties);
         
         ActivityInstrumentation.SetLogEventProperty(activity, new LogEventProperty("b", new ScalarValue(b)));
         ActivityInstrumentation.SetLogEventProperties(activity, new LogEventProperty("c", new ScalarValue(c)), new LogEventProperty("d", new ScalarValue(d)), new LogEventProperty("e", new DictionaryValue(e)));
@@ -58,13 +59,13 @@ public class ActivityInstrumentationTests
         Assert.Equal(d, activity.GetTagItem("d"));
         Assert.IsType<DictionaryValue>(activity.GetTagItem("e"));
 
-        var properties = ActivityInstrumentation.GetLogEventProperties(activity).ToList();
+        Assert.True(ActivityInstrumentation.TryGetLogEventPropertyCollection(activity, out logEventProperties));
         
         // All set properties are present
-        Assert.Equal(b, ((ScalarValue)properties.First(p => p.Name == "b").Value).Value);
-        Assert.Equal(c, ((ScalarValue)properties.First(p => p.Name == "c").Value).Value);
-        Assert.Equal(d, ((ScalarValue)properties.First(p => p.Name == "d").Value).Value);
-        Assert.NotNull(properties.First(p => p.Name == "e").Value);
+        Assert.Equal(b, ((ScalarValue)logEventProperties.Values.First(p => p.Name == "b").Value).Value);
+        Assert.Equal(c, ((ScalarValue)logEventProperties.Values.First(p => p.Name == "c").Value).Value);
+        Assert.Equal(d, ((ScalarValue)logEventProperties.Values.First(p => p.Name == "d").Value).Value);
+        Assert.NotNull(logEventProperties.Values.First(p => p.Name == "e").Value);
     }
 
     [Fact]


### PR DESCRIPTION
This is a first pass at performance analysis on the SerilogTracing pipeline. Right now I'm just looking at low-hanging fruit with a fairly unsophisticated benchmark app that creates 5,000,000 activities in a loop with 10 properties on each, logged through an empty Serilog pipeline.

These changes have an impact of around 25%:

```
before: 11973433.8us
after : 8767232.8us 
```