### PR TITLE
Avoid some allocations assembling LogEvents

### DIFF
--- a/src/SerilogTracing/Instrumentation/ActivityInstrumentation.cs
+++ b/src/SerilogTracing/Instrumentation/ActivityInstrumentation.cs
@@ -82,10 +82,10 @@ public static class ActivityInstrumentation
         }
     }
 
-    internal static void SetLogEventProperty(Activity activity, LogEventProperty property, Dictionary<string, LogEventProperty> collection)
+    internal static void SetLogEventProperty(Activity activity, LogEventProperty property, Dictionary<string, LogEventPropertyValue> collection)
     {
         activity.SetTag(property.Name, ToActivityTagValue(property.Value));
-        collection[property.Name] = property;
+        collection[property.Name] = property.Value;
     }
 
     static object? ToActivityTagValue(LogEventPropertyValue propertyValue)
@@ -93,9 +93,9 @@ public static class ActivityInstrumentation
         return propertyValue is ScalarValue sv ? sv.Value : propertyValue;
     }
 
-    internal static bool TryGetLogEventPropertyCollection(Activity activity, [NotNullWhen(true)] out Dictionary<string, LogEventProperty>? properties)
+    internal static bool TryGetLogEventPropertyCollection(Activity activity, [NotNullWhen(true)] out Dictionary<string, LogEventPropertyValue>? properties)
     {
-        if (activity.GetCustomProperty(Constants.LogEventPropertyCollectionName) is Dictionary<string, LogEventProperty> existing)
+        if (activity.GetCustomProperty(Constants.LogEventPropertyCollectionName) is Dictionary<string, LogEventPropertyValue> existing)
         {
             properties = existing;
             return true;
@@ -105,14 +105,14 @@ public static class ActivityInstrumentation
         return false;
     }
 
-    static Dictionary<string, LogEventProperty> GetOrInitLogEventPropertyCollection(Activity activity)
+    static Dictionary<string, LogEventPropertyValue> GetOrInitLogEventPropertyCollection(Activity activity)
     {
         if (TryGetLogEventPropertyCollection(activity, out var existing))
         {
             return existing;
         }
 
-        var added = new Dictionary<string, LogEventProperty>();
+        var added = new Dictionary<string, LogEventPropertyValue>();
         activity.SetCustomProperty(Constants.LogEventPropertyCollectionName, added);
 
         return added;
@@ -185,9 +185,9 @@ public static class ActivityInstrumentation
     {
         activity.SetCustomProperty(Constants.SelfPropertyName, loggerActivity);
         activity.SetCustomProperty(Constants.LogEventPropertyCollectionName, loggerActivity.Properties);
-        foreach (var (_, property) in loggerActivity.Properties)
+        foreach (var (name, value) in loggerActivity.Properties)
         {
-            activity.AddTag(property.Name, ToActivityTagValue(property.Value));
+            activity.AddTag(name, ToActivityTagValue(value));
         }
     }
     

--- a/src/SerilogTracing/LoggerActivity.cs
+++ b/src/SerilogTracing/LoggerActivity.cs
@@ -37,7 +37,7 @@ public sealed class LoggerActivity : IDisposable
 
         foreach (var capture in captures)
         {
-            Properties[capture.Name] = capture;
+            Properties[capture.Name] = capture.Value;
         }
 
         if (activity != null)
@@ -51,7 +51,7 @@ public sealed class LoggerActivity : IDisposable
     bool IsComplete { get; set; }
 
     internal MessageTemplate MessageTemplate { get; }
-    internal Dictionary<string, LogEventProperty> Properties { get; }
+    internal Dictionary<string, LogEventPropertyValue> Properties { get; }
     
     bool IsSuppressed => ActivityInstrumentation.IsSuppressed(Activity) || IsComplete;
 


### PR DESCRIPTION
Another pass on performance improvement. This one is a bit on the wild side, but lines up our internal dictionary stored on the activity with that internally stored by `LogEvent` itself to make optimizations like https://github.com/serilog/serilog/issues/2010 possible down the line.

I’ll assemble some numbers and GC impact once everything has shaken out.