### PR TITLE
Ensure ASP.NET instrumentation is called on all activities

### DIFF
--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
@@ -22,7 +22,7 @@ namespace SerilogTracing.Instrumentation.AspNetCore;
 /// <summary>
 /// An activity instrumentor that populates the current activity with context from incoming HTTP requests.
 /// </summary>
-sealed class HttpRequestInActivityInstrumentor : IActivityInstrumentor
+sealed class HttpRequestInActivityInstrumentor : IActivityInstrumentor, IInstrumentationEventObserver
 {
     /// <summary>
     /// Create an instance of the instrumentor.
@@ -58,10 +58,22 @@ sealed class HttpRequestInActivityInstrumentor : IActivityInstrumentor
     {
         return diagnosticListenerName == DiagnosticListenerName;
     }
-
-    /// <inheritdoc />
+    
     public void InstrumentActivity(Activity activity, string eventName, object eventArgs)
     {
+        // Instrumentation is applied in `OnDiagnosticEvent`.
+    }
+
+    /// <inheritdoc />
+    public void OnNext(string eventName, object? eventArgs)
+    {
+        var activity = Activity.Current;
+
+        if (activity == null || eventArgs == null)
+        {
+            return;
+        }
+        
         switch (eventName)
         {
             case "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start":

--- a/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentor.cs
+++ b/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentor.cs
@@ -55,12 +55,17 @@ sealed class SqlCommandActivityInstrumentor(SqlCommandActivityInstrumentationOpt
                     var child = ActivitySource.StartActivity(_messageTemplateOverride.Text, ActivityKind.Client);
                     if (child == null)
                         return;
-
+                    
                     child.DisplayName = _messageTemplateOverride.Text;
 
                     if (!child.IsAllDataRequested)
                     {
                         return;
+                    }
+                    
+                    if (child.Parent == null)
+                    {
+                        child.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
                     }
 
                     ActivityInstrumentation.SetMessageTemplateOverride(child, _messageTemplateOverride);


### PR DESCRIPTION
This PR contains some more fixes around recording spans for activities generated by ASP.NET Core and SQL Client. Instrumentation will only currently be called if an activity is intended to be instrumented, but we also need instrumentation to ensure activities will be recorded.