### PR TITLE
Fix default sampling option - should be `AllDataAndRecorded`

### DIFF
--- a/example/Example.WeatherService/Program.cs
+++ b/example/Example.WeatherService/Program.cs
@@ -18,7 +18,7 @@ Log.Logger = new LoggerConfiguration()
     .CreateLogger();
 
 using var _ = new ActivityListenerConfiguration()
-    .Instrument.AspNetCoreRequests()
+    .Instrument.AspNetCoreRequests(opts => opts.IncomingTraceParent = IncomingTraceParent.Trust)
     .TraceToSharedLogger();
 
 Log.Information("Weather service starting up");

--- a/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentor.cs
+++ b/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentor.cs
@@ -62,11 +62,6 @@ sealed class SqlCommandActivityInstrumentor(SqlCommandActivityInstrumentationOpt
                     {
                         return;
                     }
-                    
-                    if (child.Parent == null)
-                    {
-                        child.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
-                    }
 
                     ActivityInstrumentation.SetMessageTemplateOverride(child, _messageTemplateOverride);
 

--- a/src/SerilogTracing/Interop/LoggerActivityListener.cs
+++ b/src/SerilogTracing/Interop/LoggerActivityListener.cs
@@ -60,7 +60,7 @@ sealed class LoggerActivityListener: IDisposable
                         .IsEnabled(GetInitialLevel(levelMap, activity.Source.Name)))
                     return ActivitySamplingResult.None;
 
-                return sample?.Invoke(ref activity) ?? ActivitySamplingResult.AllData;
+                return sample?.Invoke(ref activity) ?? ActivitySamplingResult.AllDataAndRecorded;
             };
 
             activityListener.ActivityStopped += activity =>

--- a/src/SerilogTracing/Interop/LoggerActivitySource.cs
+++ b/src/SerilogTracing/Interop/LoggerActivitySource.cs
@@ -32,12 +32,6 @@ static class LoggerActivitySource
             // should the logging layer.
             var listenerActivity = Instance.CreateActivity(name, ActivityKind.Internal);
 
-            // If this is the root activity then mark it as recorded
-            if (listenerActivity is { ParentId: null })
-            {
-                listenerActivity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
-            }
-
             listenerActivity?.Start();
 
             return listenerActivity;


### PR DESCRIPTION
An early mistake here led to some brittle, defensive code, which should now be gone :-)

**TL;DR** is that when configuring ASP.NET Core instrumentation, if you're building an internal service, choose `opts.IncomingTraceParent = IncomingTraceParent.Trust`, if it's external use `IncomingTraceParent.Ignore`, and if you are unsure, leave it as the default `IncomingTraceParent.Accept`, with some caveats when sampling is not configured deterministically.

Fixes #67 