### PR TITLE
Collect and propagate `Activity.Kind` in `Properties["SpanKind"]`

### DIFF
--- a/serilog-tracing.sln.DotSettings
+++ b/serilog-tracing.sln.DotSettings
@@ -1,7 +1,9 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MD/@EntryIndexedValue">MD</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enrichers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Evented/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Instrumentor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Instrumentors/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Otlp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=uninstrumented/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/SerilogTracing.Expressions/TracingFunctions.cs
+++ b/src/SerilogTracing.Expressions/TracingFunctions.cs
@@ -108,4 +108,17 @@ static class TracingFunctions
 
         return null;
     }
+
+    public static LogEventPropertyValue? ToUpperInvariant(LogEventPropertyValue? value)
+    {
+        // In Serilog.Expressions we'd use Coerce.String() here.
+        var s = value switch
+        {
+            ScalarValue { Value: string str } => str,
+            ScalarValue { Value: { } v } when v.GetType().IsEnum => v.ToString(),
+            _ => null
+        };
+
+        return s is null ? null : new ScalarValue(s.ToUpperInvariant());
+    }
 }

--- a/src/SerilogTracing.Expressions/TracingFunctions.cs
+++ b/src/SerilogTracing.Expressions/TracingFunctions.cs
@@ -14,6 +14,7 @@
 
 using System.Diagnostics;
 using Serilog.Events;
+using Serilog.Formatting.Json;
 using SerilogTracing.Core;
 
 // Plug-in functions have a standard signature with nullable return type.
@@ -31,6 +32,7 @@ namespace SerilogTracing.Expressions;
 static class TracingFunctions
 {
     static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    static readonly JsonValueFormatter JsonValueFormatter = new("$type");
 
     public static LogEventPropertyValue? Elapsed(LogEvent logEvent)
     {
@@ -120,5 +122,27 @@ static class TracingFunctions
         };
 
         return s is null ? null : new ScalarValue(s.ToUpperInvariant());
+    }
+
+    public static LogEventPropertyValue? AsStringTags(LogEventPropertyValue? value)
+    {
+        if (value is not StructureValue sv) return null;
+
+        return new StructureValue(sv.Properties
+                .Select(p =>
+                {
+                    switch (p.Value)
+                    {
+                        case ScalarValue { Value: string }:
+                            return p;
+                        case ScalarValue { Value: null }:
+                            return new LogEventProperty(p.Name, new ScalarValue(""));
+                        default:
+                            var sw = new StringWriter();
+                            JsonValueFormatter.Format(p.Value, sw);
+                            return new LogEventProperty(p.Name, new ScalarValue(sw.ToString()));
+                    }
+                }),
+            sv.TypeTag);
     }
 }

--- a/src/SerilogTracing.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/SerilogTracing.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -19,6 +19,7 @@ using Serilog.Sinks.PeriodicBatching;
 using SerilogTracing.Collections;
 using SerilogTracing.Sinks.OpenTelemetry;
 using SerilogTracing.Sinks.OpenTelemetry.Exporters;
+// ReSharper disable MemberCanBePrivate.Global
 
 namespace SerilogTracing;
 
@@ -74,7 +75,6 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         {
             var openTelemetryTracesSink = new OpenTelemetryTracesSink(
                 exporter: exporter,
-                formatProvider: options.FormatProvider,
                 resourceAttributes: new Dictionary<string, object>(options.ResourceAttributes),
                 includedData: options.IncludedData);
 
@@ -170,7 +170,6 @@ public static class OpenTelemetryLoggerConfigurationExtensions
         {
             tracesSink = new OpenTelemetryTracesSink(
                 exporter: exporter,
-                formatProvider: options.FormatProvider,
                 resourceAttributes: new Dictionary<string, object>(options.ResourceAttributes),
                 includedData: options.IncludedData);
         }

--- a/src/SerilogTracing.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetryTracesSink.cs
+++ b/src/SerilogTracing.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetryTracesSink.cs
@@ -23,19 +23,16 @@ namespace SerilogTracing.Sinks.OpenTelemetry;
 
 class OpenTelemetryTracesSink : IBatchedLogEventSink, ILogEventSink
 {
-    readonly IFormatProvider? _formatProvider;
     readonly ResourceSpans _resourceSpansTemplate;
     readonly IExporter _exporter;
     readonly IncludedData _includedData;
 
     public OpenTelemetryTracesSink(
         IExporter exporter,
-        IFormatProvider? formatProvider,
         IReadOnlyDictionary<string, object> resourceAttributes,
         IncludedData includedData)
     {
         _exporter = exporter;
-        _formatProvider = formatProvider;
         _includedData = includedData;
 
         if ((includedData & IncludedData.SpecRequiredResourceAttributes) == IncludedData.SpecRequiredResourceAttributes)
@@ -58,7 +55,7 @@ class OpenTelemetryTracesSink : IBatchedLogEventSink, ILogEventSink
 
         foreach (var logEvent in batch)
         {
-            var (span, scopeName) = OtlpEventBuilder.ToSpan(logEvent, _formatProvider, _includedData);
+            var (span, scopeName) = OtlpEventBuilder.ToSpan(logEvent, _includedData);
             if (scopeName == null)
             {
                 if (traceAnonymousScope == null)
@@ -94,7 +91,7 @@ class OpenTelemetryTracesSink : IBatchedLogEventSink, ILogEventSink
     /// </summary>
     public void Emit(LogEvent logEvent)
     {
-        var (span, scopeName) = OtlpEventBuilder.ToSpan(logEvent, _formatProvider, _includedData);
+        var (span, scopeName) = OtlpEventBuilder.ToSpan(logEvent, _includedData);
         var scopeSpans = RequestTemplateFactory.CreateScopeSpans(scopeName);
         scopeSpans.Spans.Add(span);
         var resourceSpans = _resourceSpansTemplate.Clone();

--- a/src/SerilogTracing.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
+++ b/src/SerilogTracing.Sinks.OpenTelemetry/Sinks/OpenTelemetry/ProtocolHelpers/PrimitiveConversions.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
@@ -237,5 +238,17 @@ static class PrimitiveConversions
         md5.Initialize();
         var hash = md5.ComputeHash(Encoding.UTF8.GetBytes(s));
         return string.Join(string.Empty, Array.ConvertAll(hash, x => x.ToString("x2")));
+    }
+
+    public static Span.Types.SpanKind ToOpenTelemetrySpanKind(ActivityKind kind)
+    {
+        return kind switch
+        {
+            ActivityKind.Server => Span.Types.SpanKind.Server,
+            ActivityKind.Client => Span.Types.SpanKind.Client,
+            ActivityKind.Producer => Span.Types.SpanKind.Producer,
+            ActivityKind.Consumer => Span.Types.SpanKind.Consumer,
+            _ => Span.Types.SpanKind.Internal,
+        };
     }
 }

--- a/src/SerilogTracing.Sinks.Seq/SeqTracingLoggerSinkConfigurationExtensions.cs
+++ b/src/SerilogTracing.Sinks.Seq/SeqTracingLoggerSinkConfigurationExtensions.cs
@@ -30,7 +30,8 @@ namespace SerilogTracing;
 public static class SeqTracingLoggerSinkConfigurationExtensions
 {
     static ITextFormatter CreatePayloadFormatter() => new ExpressionTemplate(
-        "{ {@t, @mt, @l: if @l = 'Information' then undefined() else @l, @x, @sp, @tr, @ps: ParentSpanId, @st: SpanStartTimestamp, ..rest()} }\n");
+        // SpanKind is dropped out; Seq may at some point accept this in a top-level property.
+        "{ {@t, @mt, @l: if @l = 'Information' then undefined() else @l, @x, @sp, @tr, @ps: ParentSpanId, @st: SpanStartTimestamp, SpanKind: undefined(), ..rest()} }\n");
 
     static HttpMessageHandler? CreateDefaultHttpMessageHandler() =>
 #if FEATURE_SOCKETS_HTTP_HANDLER

--- a/src/SerilogTracing.Sinks.Zipkin/Sinks/Zipkin/ZipkinSink.cs
+++ b/src/SerilogTracing.Sinks.Zipkin/Sinks/Zipkin/ZipkinSink.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Serilog.Events;
-using Serilog.Expressions;
 using Serilog.Sinks.PeriodicBatching;
 using Serilog.Templates;
 using SerilogTracing.Core;
@@ -23,7 +22,7 @@ class ZipkinSink : IBatchedLogEventSink
             duration: Microseconds(Elapsed()),
             kind: ToUpperInvariant(SpanKind),
             localEndpoint: {serviceName: Application},
-            tags: rest()
+            tags: AsStringTags(rest())
         }
     }
     """, nameResolver: new TracingNameResolver());

--- a/src/SerilogTracing.Sinks.Zipkin/Sinks/Zipkin/ZipkinSink.cs
+++ b/src/SerilogTracing.Sinks.Zipkin/Sinks/Zipkin/ZipkinSink.cs
@@ -21,6 +21,7 @@ class ZipkinSink : IBatchedLogEventSink
             name: @m,
             timestamp: Microseconds(FromUnixEpoch(SpanStartTimestamp)),
             duration: Microseconds(Elapsed()),
+            kind: ToUpperInvariant(SpanKind),
             localEndpoint: {serviceName: Application},
             tags: rest()
         }

--- a/src/SerilogTracing/Core/Constants.cs
+++ b/src/SerilogTracing/Core/Constants.cs
@@ -38,6 +38,14 @@ public static class Constants
     /// span's start timestamp. All spans emitted by SerilogTracing carry this property.
     /// </summary>
     public const string SpanStartTimestampPropertyName = "SpanStartTimestamp";
+    
+    /// <summary>
+    /// The name of the entry in <see cref="LogEvent.Properties"/> that carries a
+    /// span's kind. The value will be an <see cref="ActivityKind"/>. The span kind is
+    /// unset for <see cref="ActivityKind.Internal"/> spans: any span without an explicit
+    /// kind should be assumed to be internal.
+    /// </summary>
+    public const string SpanKindPropertyName = "SpanKind";
 
     internal const string LogEventPropertyCollectionName = "SerilogTracing.LogEventPropertyCollection";
     internal const string SelfPropertyName = "SerilogTracing.LoggerActivity.Self";

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -88,6 +88,7 @@ namespace SerilogTracing.Core
     {
         public const string ParentSpanIdPropertyName = "ParentSpanId";
         public const string SerilogActivitySourceName = "Serilog";
+        public const string SpanKindPropertyName = "SpanKind";
         public const string SpanStartTimestampPropertyName = "SpanStartTimestamp";
     }
 }

--- a/test/SerilogTracing.Sinks.OpenTelemetry.Tests/OtlpEventBuilderTests.cs
+++ b/test/SerilogTracing.Sinks.OpenTelemetry.Tests/OtlpEventBuilderTests.cs
@@ -33,11 +33,11 @@ public class OtlpEventBuilderTests
         var logEvent = Some.DefaultSerilogEvent();
 
         logEvent.AddOrUpdateProperty(new LogEventProperty("property_name", new ScalarValue("ok")));
-        logEvent.AddOrUpdateProperty(new LogEventProperty(SerilogTracing.Core.Constants.SpanStartTimestampPropertyName, new ScalarValue(new DateTime(2024, 8, 22, 10, 30, 0))));
+        logEvent.AddOrUpdateProperty(new LogEventProperty(Core.Constants.SpanStartTimestampPropertyName, new ScalarValue(new DateTime(2024, 8, 22, 10, 30, 0))));
 
-        var span = OtlpEventBuilder.ToSpan(logEvent, null, OpenTelemetrySinkOptions.DefaultIncludedData);
-        var propertyKeyValue = PrimitiveConversions.NewStringAttribute("property_name", "ok");
-
+        var (span, _) = OtlpEventBuilder.ToSpan(logEvent, OpenTelemetrySinkOptions.DefaultIncludedData);
+        Assert.Equal(logEvent.MessageTemplate.Text, span.Name);
+        Assert.Equal(Span.Types.SpanKind.Internal, span.Kind);
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public class OtlpEventBuilderTests
 
         var logRecord = new LogRecord();
         var logEvent = Some.SerilogEvent(Some.TestMessageTemplate, timestamp: now);
-        logEvent.AddOrUpdateProperty(new LogEventProperty(SerilogTracing.Core.Constants.SpanStartTimestampPropertyName, new ScalarValue(DateTime.UtcNow)));
+        logEvent.AddOrUpdateProperty(new LogEventProperty(Core.Constants.SpanStartTimestampPropertyName, new ScalarValue(DateTime.UtcNow)));
 
         OtlpEventBuilder.ProcessTimestamp(logRecord, logEvent);
 

--- a/test/SerilogTracing.Tests/ExternalActivityTests.cs
+++ b/test/SerilogTracing.Tests/ExternalActivityTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using Serilog;
 using Serilog.Events;
+using SerilogTracing.Core;
 using SerilogTracing.Tests.Support;
 using Xunit;
 
@@ -23,12 +24,13 @@ public class ExternalActivityTests
 
         using var _ = new ActivityListenerConfiguration().TraceTo(logger);
 
-        using var activity = source.StartActivity()!;
+        using var activity = source.StartActivity(ActivityKind.Client)!;
         activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
         activity.Stop();
 
         Assert.Equal(LogEventLevel.Information, sink.SingleEvent.Level);
         Assert.Equal(activity.DisplayName, sink.SingleEvent.RenderMessage());
+        Assert.Equal(ActivityKind.Client, ((ScalarValue)sink.SingleEvent.Properties[Constants.SpanKindPropertyName]).Value);
     }
 
     [Fact]

--- a/test/SerilogTracing.Tests/LoggerActivityTests.cs
+++ b/test/SerilogTracing.Tests/LoggerActivityTests.cs
@@ -57,7 +57,7 @@ public class LoggerActivityTests
     }
 
     [Fact]
-    public void ActivitySuppression()
+    public void NullActivityCausesLogEventSuppression()
     {
         var sink = new CollectingSink();
 
@@ -73,7 +73,7 @@ public class LoggerActivityTests
     }
 
     [Fact]
-    public void ActivityDataSuppression()
+    public void IsAllDataRequestedFalseCausesEnrichmentSuppression()
     {
         var sink = new CollectingSink();
 


### PR DESCRIPTION
A number of back-ends use span kinds to customize the display or processing of a span.

This PR adds kinds to the data model, and updates the included sinks to make use of them where appropriate.

In Zipkin, before:

![image](https://github.com/serilog-tracing/serilog-tracing/assets/342712/70f8ffd7-203d-44a2-b9ae-89c7b6ada4de)

In Zipkin, after:

![image](https://github.com/serilog-tracing/serilog-tracing/assets/342712/5a6fb2fa-c472-4b51-b061-584d44c46559)

Since Jaeger accepts Zipkin traces I thought I'd use that to validate the Zipkin sink, and found some issues. Here's the final result in Jaeger:

![image](https://github.com/serilog-tracing/serilog-tracing/assets/342712/3521d122-1a14-4be1-8aaa-2eb3fe61b5e8)
