### PR TITLE
Rename the replacement ASP.NET Core activity source

### DIFF
--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
@@ -156,10 +156,6 @@ sealed class HttpRequestInActivityInstrumentor : IActivityInstrumentor, IInstrum
     static Activity? CreateReplacementActivity(Activity? incoming, bool inheritTags, bool inheritParent, bool inheritFlags, bool inheritBaggage)
     {
         var replacement = ReplacementActivitySource.CreateActivity(DefaultActivityName, ActivityKind.Server);
-        if (replacement?.IsAllDataRequested == true)
-        {
-            replacement.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
-        }
 
         if (incoming == null)
         {

--- a/src/SerilogTracing.Instrumentation.AspNetCore/SerilogTracing.Instrumentation.AspNetCore.csproj
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/SerilogTracing.Instrumentation.AspNetCore.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <ProjectReference Include="..\SerilogTracing\SerilogTracing.csproj" />
+        <InternalsVisibleTo Include="SerilogTracing.Instrumentation.AspNetCore.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a754c81a195a80e95b1638ebfa4d94281b4852f386a3de19794418f68acb0564da8a4ced775b1de531d640768186ceef422cdabb8c115055cf734971913672c4be1385d08902ef2a792786339725fb989d5cf64aea4e0703ee7d4e8b16426d8e6b61cb3479f33cdec568e2dd631f0fbb9f092702734a19e9964fadbd30bc619c" />
     </ItemGroup>
 
 </Project>

--- a/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentor.cs
+++ b/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentor.cs
@@ -25,7 +25,7 @@ sealed class SqlCommandActivityInstrumentor(SqlCommandActivityInstrumentationOpt
 {
     const string DiagnosticListenerName = "SqlClientDiagnosticListener";
 
-    static readonly ActivitySource ActivitySource = new(typeof(SqlCommandActivityInstrumentor).Assembly.GetName().Name!);
+    static readonly ActivitySource ActivitySource = new("SerilogTracing.Instrumentation.SqlClient");
 
     readonly MessageTemplate _messageTemplateOverride = new MessageTemplateParser().Parse("SQL {Operation} {Database}");
     readonly PropertyAccessor<SqlCommand> _getCommand = new("Command");

--- a/test/SerilogTracing.Instrumentation.AspNetCore.Tests/HttpRequestInActivityInstrumentorTests.cs
+++ b/test/SerilogTracing.Instrumentation.AspNetCore.Tests/HttpRequestInActivityInstrumentorTests.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics;
+using SerilogTracing.Tests.Support;
+using Xunit;
+
+namespace SerilogTracing.Instrumentation.AspNetCore.Tests;
+
+public class HttpRequestInActivityInstrumentorTests
+{
+    static Activity CreateIncoming()
+    {
+        var incoming = new Activity(Some.String());
+        // ReSharper disable once RedundantArgumentDefaultValue
+        incoming.SetParentId(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None);
+        incoming.SetBaggage(Some.String(), Some.String());
+        incoming.SetTag(Some.String(), Some.String());
+        return incoming;
+    }
+
+    [Theory]
+    [InlineData(IncomingTraceParent.Trust)]
+    [InlineData(IncomingTraceParent.Ignore)]
+    [InlineData(IncomingTraceParent.Accept)]
+    public void AllModesSucceedWithNoParent(IncomingTraceParent incomingTraceParent)
+    {
+        using var listener = Some.AlwaysOnListenerFor(HttpRequestInActivityInstrumentor.ReplacementActivitySourceName);
+        var replacement = HttpRequestInActivityInstrumentor.CreateReplacementActivity(null, incomingTraceParent);
+        Assert.NotNull(replacement);
+        Assert.Equal(default, replacement.ParentSpanId);
+        Assert.Equal(ActivityTraceFlags.Recorded, replacement.ActivityTraceFlags);
+    }
+    
+    [Fact]
+    public void NoDetailsAreInheritedInIgnoreMode()
+    {
+        using var listener = Some.AlwaysOnListenerFor(HttpRequestInActivityInstrumentor.ReplacementActivitySourceName);
+        var incoming = CreateIncoming();
+        var replacement = HttpRequestInActivityInstrumentor.CreateReplacementActivity(incoming, IncomingTraceParent.Ignore);
+        Assert.NotNull(replacement);
+        Assert.NotEqual(incoming.TraceId, replacement.TraceId);
+        Assert.Equal(default, replacement.ParentSpanId);
+        Assert.NotEqual(incoming.ActivityTraceFlags, replacement.ActivityTraceFlags);
+        Assert.Empty(replacement.Baggage);
+        Assert.Empty(replacement.TagObjects);
+    }
+    
+    [Fact]
+    public void LimitedDetailsAreInheritedInAcceptMode()
+    {
+        using var listener = Some.AlwaysOnListenerFor(HttpRequestInActivityInstrumentor.ReplacementActivitySourceName);
+        var incoming = CreateIncoming();
+        var replacement = HttpRequestInActivityInstrumentor.CreateReplacementActivity(incoming, IncomingTraceParent.Accept);
+        Assert.NotNull(replacement);
+        Assert.Equal(incoming.TraceId, replacement.TraceId);
+        Assert.Equal(incoming.ParentSpanId, replacement.ParentSpanId);
+        Assert.NotEqual(incoming.ActivityTraceFlags, replacement.ActivityTraceFlags);
+        Assert.Empty(replacement.Baggage);
+        Assert.NotEmpty(replacement.TagObjects);
+    }
+    
+    [Fact]
+    public void AllDetailsAreInheritedInTrustMode()
+    {
+        using var listener = Some.AlwaysOnListenerFor(HttpRequestInActivityInstrumentor.ReplacementActivitySourceName);
+        var incoming = CreateIncoming();
+        var replacement = HttpRequestInActivityInstrumentor.CreateReplacementActivity(incoming, IncomingTraceParent.Trust);
+        Assert.NotNull(replacement);
+        Assert.Equal(incoming.TraceId, replacement.TraceId);
+        Assert.Equal(incoming.ParentSpanId, replacement.ParentSpanId);
+        Assert.Equal(incoming.ActivityTraceFlags, replacement.ActivityTraceFlags);
+        Assert.NotEmpty(replacement.Baggage);
+        Assert.NotEmpty(replacement.TagObjects);
+    }
+}

--- a/test/SerilogTracing.Instrumentation.AspNetCore.Tests/SerilogTracing.Instrumentation.AspNetCore.Tests.csproj
+++ b/test/SerilogTracing.Instrumentation.AspNetCore.Tests/SerilogTracing.Instrumentation.AspNetCore.Tests.csproj
@@ -17,7 +17,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\SerilogTracing.Instrumentation.AspNetCore\SerilogTracing.Instrumentation.AspNetCore.csproj" />
+        <ProjectReference Include="..\..\src\SerilogTracing.Instrumentation.AspNetCore\SerilogTracing.Instrumentation.AspNetCore.csproj" />
+        <ProjectReference Include="..\SerilogTracing.Tests\SerilogTracing.Tests.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/SerilogTracing.Tests/Support/Some.cs
+++ b/test/SerilogTracing.Tests/Support/Some.cs
@@ -4,7 +4,7 @@ using Serilog.Parsing;
 
 namespace SerilogTracing.Tests.Support;
 
-static class Some
+public static class Some
 {
     public static string String()
     {

--- a/test/SerilogTracing.Tests/Support/Some.cs
+++ b/test/SerilogTracing.Tests/Support/Some.cs
@@ -66,7 +66,7 @@ public static class Some
     {
         var listener = new ActivityListener();
         listener.ShouldListenTo = source => source.Name == sourceName;
-        listener.Sample = (ref ActivityCreationOptions<ActivityContext> ctx) => ctx.Source.Name == sourceName ? ActivitySamplingResult.AllData : ActivitySamplingResult.None;
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> ctx) => ctx.Source.Name == sourceName ? ActivitySamplingResult.AllDataAndRecorded : ActivitySamplingResult.None;
         System.Diagnostics.ActivitySource.AddActivityListener(listener);
         return listener;
     }


### PR DESCRIPTION
Previously, we impersonated the `Microsoft.AspNetCore` activity source when instrumenting ASP.NET Core requests. This has a couple of drawbacks -

 * it goes against the expectation that activity source names will match the assemblies that expose them,
 * Serilog setups often have a `MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)` which then, inadvertently, turns tracing off.

There's a good argument _against_ making this change, too - by effectively ignoring the `Microsoft.AspNetCore` source, we may end up out of sync with future changes in its behavior. Right now, ASP.NET Core uses `new Activity()` to ensure there's always some record of incoming trace ids/parents, but it's possible that in the future there will be some changes here, e.g. to better respect sampling decisions, and we may be broken by this.

On the whole though, I think aiming for a good experience now, and adapting as needed, is sound.