### PR TITLE
Don't mark redirected `HttpClient` requests as errors

### DIFF
--- a/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentor.cs
@@ -82,14 +82,10 @@ sealed class HttpRequestOutActivityInstrumentor : IActivityInstrumentor
 
                     if (activity.Status == ActivityStatusCode.Unset)
                     {
-                        if (statusCode >= 400)
+                        if (statusCode >= 400 ||
+                            _requestTaskStatusAccessor.TryGetValue(eventArgs, out var requestTaskStatus) && requestTaskStatus == TaskStatus.Faulted)
                         {
                             activity.SetStatus(ActivityStatusCode.Error);
-                        }
-                        else if (_requestTaskStatusAccessor.TryGetValue(eventArgs, out var requestTaskStatus))
-                        {
-                            if (requestTaskStatus == TaskStatus.Faulted || response is { IsSuccessStatusCode: false })
-                                activity.SetStatus(ActivityStatusCode.Error);
                         }
                     }
 


### PR DESCRIPTION
My last round of changes here introduced a bug - `IsSuccessStatusCode` is `false` for redirects, so we're marking 3xx requests as errors.

Need some additional test coverage around this, but keen to push through a fix because it's an annoying glitch.