### PR TITLE
Rename the embedded `ActivitySource` from "Serilog" to "SerilogTracing"

### DIFF
--- a/src/SerilogTracing/Core/Constants.cs
+++ b/src/SerilogTracing/Core/Constants.cs
@@ -25,7 +25,7 @@ public static class Constants
     /// <summary>
     /// The name of the <see cref="ActivitySource"/> through which SerilogTracing publishes logger activities.
     /// </summary>
-    public const string SerilogActivitySourceName = "Serilog";
+    public const string SerilogTracingActivitySourceName = "SerilogTracing";
 
     /// <summary>
     /// The name of the entry in <see cref="LogEvent.Properties"/> that carries a

--- a/src/SerilogTracing/Interop/LoggerActivitySource.cs
+++ b/src/SerilogTracing/Interop/LoggerActivitySource.cs
@@ -19,7 +19,7 @@ namespace SerilogTracing.Interop;
 
 static class LoggerActivitySource
 {
-    static ActivitySource Instance { get; } = new(Constants.SerilogActivitySourceName, null);
+    static ActivitySource Instance { get; } = new(Constants.SerilogTracingActivitySourceName, null);
 
     public static Activity? TryStartActivity(string name)
     {

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -87,7 +87,7 @@ namespace SerilogTracing.Core
     public static class Constants
     {
         public const string ParentSpanIdPropertyName = "ParentSpanId";
-        public const string SerilogActivitySourceName = "Serilog";
+        public const string SerilogTracingActivitySourceName = "SerilogTracing";
         public const string SpanKindPropertyName = "SpanKind";
         public const string SpanStartTimestampPropertyName = "SpanStartTimestamp";
     }


### PR DESCRIPTION
The name of this activity source was a somewhat arbitrary decision early on; using `SerilogTracing` as the name here is least surprising.