### PR TITLE
Some basic benchmarks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,8 @@
         <VersionPrefix>1.0.0</VersionPrefix>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <SignAssembly>true</SignAssembly>
+        <!-- The condition is required to support BenchmarkDotNet -->
+        <SignAssembly Condition="Exists('../../assets/SerilogTracing.snk')">true</SignAssembly>
         <AssemblyOriginatorKeyFile>../../assets/SerilogTracing.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
 </Project>

--- a/serilog-tracing.sln
+++ b/serilog-tracing.sln
@@ -62,6 +62,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".workflows", ".workflows", 
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerilogTracing.Benchmarks", "test\SerilogTracing.Benchmarks\SerilogTracing.Benchmarks.csproj", "{9052EA54-5BEE-4203-8966-DEC013DE62CB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +88,7 @@ Global
 		{9D94FDB0-546F-46FD-AFF1-9E48C7BA24E6} = {92FDF45D-CCCD-4BEA-A5E3-CC8ECEF34472}
 		{0128EB76-9B60-4553-B089-2D1707CD0D65} = {92FDF45D-CCCD-4BEA-A5E3-CC8ECEF34472}
 		{ECE478F5-0719-4E59-8AEF-6AB12BE33B62} = {6BB7BDF8-8AEE-4D76-9E81-EA9984A66BF6}
+		{9052EA54-5BEE-4203-8966-DEC013DE62CB} = {92FDF45D-CCCD-4BEA-A5E3-CC8ECEF34472}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2D5CE076-4A88-41C1-961B-A26ABA88E6F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -144,5 +147,9 @@ Global
 		{0128EB76-9B60-4553-B089-2D1707CD0D65}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0128EB76-9B60-4553-B089-2D1707CD0D65}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0128EB76-9B60-4553-B089-2D1707CD0D65}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9052EA54-5BEE-4203-8966-DEC013DE62CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9052EA54-5BEE-4203-8966-DEC013DE62CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9052EA54-5BEE-4203-8966-DEC013DE62CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9052EA54-5BEE-4203-8966-DEC013DE62CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/SerilogTracing.Sinks.OpenTelemetry/SerilogTracing.Sinks.OpenTelemetry.csproj
+++ b/src/SerilogTracing.Sinks.OpenTelemetry/SerilogTracing.Sinks.OpenTelemetry.csproj
@@ -16,8 +16,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<SignAssembly>true</SignAssembly>
-		<AssemblyOriginatorKeyFile>..\..\assets\SerilogTracing.snk</AssemblyOriginatorKeyFile>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 	</PropertyGroup>
 	

--- a/src/SerilogTracing/ActivityListenerConfiguration.cs
+++ b/src/SerilogTracing/ActivityListenerConfiguration.cs
@@ -79,10 +79,12 @@ public class ActivityListenerConfiguration
     /// The logger instance to emit traces through. Avoid using the shared <see cref="Log.Logger" /> as
     /// the value here. To emit traces through the shared static logger, call <see cref="TraceToSharedLogger" /> instead.
     /// </param>
+    /// <param name="ignoreLevelChanges">If <c langword="true"/>, the activity listener will assume all initial and
+    /// minimum levels are fixed at the time of activity listener creation. This may slightly improve tracing performance.</param>
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
-    public IDisposable TraceTo(ILogger logger)
+    public IDisposable TraceTo(ILogger logger, bool ignoreLevelChanges = false)
     {
-        return LoggerActivityListener.Configure(this, () => logger);
+        return LoggerActivityListener.Configure(this, () => logger, ignoreLevelChanges);
     }
 
     /// <summary>
@@ -94,6 +96,6 @@ public class ActivityListenerConfiguration
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
     public IDisposable TraceToSharedLogger()
     {
-        return LoggerActivityListener.Configure(this, () => Log.Logger);
+        return LoggerActivityListener.Configure(this, () => Log.Logger, false);
     }
 }

--- a/src/SerilogTracing/ActivityListenerConfiguration.cs
+++ b/src/SerilogTracing/ActivityListenerConfiguration.cs
@@ -79,12 +79,10 @@ public class ActivityListenerConfiguration
     /// The logger instance to emit traces through. Avoid using the shared <see cref="Log.Logger" /> as
     /// the value here. To emit traces through the shared static logger, call <see cref="TraceToSharedLogger" /> instead.
     /// </param>
-    /// <param name="ignoreLevelChanges">If <c langword="true"/>, the activity listener will assume all initial and
-    /// minimum levels are fixed at the time of activity listener creation. This may slightly improve tracing performance.</param>
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
-    public IDisposable TraceTo(ILogger logger, bool ignoreLevelChanges = false)
+    public IDisposable TraceTo(ILogger logger)
     {
-        return LoggerActivityListener.Configure(this, () => logger, ignoreLevelChanges);
+        return LoggerActivityListener.Configure(this, () => logger, ignoreLevelChanges: false);
     }
 
     /// <summary>
@@ -96,6 +94,6 @@ public class ActivityListenerConfiguration
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
     public IDisposable TraceToSharedLogger()
     {
-        return LoggerActivityListener.Configure(this, () => Log.Logger, false);
+        return LoggerActivityListener.Configure(this, () => Log.Logger, ignoreLevelChanges: false);
     }
 }

--- a/src/SerilogTracing/Core/LevelOverrideMap.cs
+++ b/src/SerilogTracing/Core/LevelOverrideMap.cs
@@ -55,7 +55,7 @@ class LevelOverrideMap
 
         // Descending order means that if we have a match, we're sure about it being the most specific.
         _overrides = overrides
-            .OrderByDescending(o => o.Key)
+            .OrderByDescending(o => o.Key, StringComparer.Ordinal)
             .Select(o => new LevelOverride(o.Key, o.Value))
             .ToArray();
     }
@@ -67,7 +67,7 @@ class LevelOverrideMap
     {
         foreach (var levelOverride in _overrides)
         {
-            if (context.StartsWith(levelOverride.Context) &&
+            if (context.StartsWith(levelOverride.Context, StringComparison.Ordinal) &&
                 (context.Length == levelOverride.Context.Length || context[levelOverride.Context.Length] == '.'))
             {
                 minimumLevel = LevelAlias.Minimum;

--- a/test/SerilogTracing.Benchmarks/LoggerActivityLeveledOffBenchmarks.cs
+++ b/test/SerilogTracing.Benchmarks/LoggerActivityLeveledOffBenchmarks.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Attributes;
+using Serilog;
+using Serilog.Events;
+
+namespace SerilogTracing.Benchmarks;
+
+/// <summary>
+/// These benchmarks cover usage when the intended span is suppressed through logger levelling. The cost in this
+/// case is the same regardless of whether and how tracing is configured.
+/// </summary>
+[MemoryDiagnoser]
+public class LoggerActivityLeveledOffBenchmarks
+{
+    readonly ILogger _log = new LoggerConfiguration().MinimumLevel.Is(LevelAlias.Off).CreateLogger();
+    readonly Exception _exception = new();
+
+    [Benchmark]
+    public LoggerActivity StartThenDispose()
+    {
+        var activity = _log.StartActivity("Benchmark");
+        activity.Dispose();
+        return activity;
+    }
+    
+    [Benchmark]
+    public LoggerActivity StartThenComplete()
+    {
+        var activity = _log.StartActivity("Benchmark");
+        activity.Complete(LogEventLevel.Error, _exception);
+        return activity;
+    }
+}

--- a/test/SerilogTracing.Benchmarks/LoggerActivityLeveledOffBenchmarks.cs
+++ b/test/SerilogTracing.Benchmarks/LoggerActivityLeveledOffBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
 using Serilog;
 using Serilog.Events;
@@ -9,10 +10,19 @@ namespace SerilogTracing.Benchmarks;
 /// case is the same regardless of whether and how tracing is configured.
 /// </summary>
 [MemoryDiagnoser]
-public class LoggerActivityLeveledOffBenchmarks
+public class LoggerActivityLeveledOffBenchmarks : IDisposable
 {
     readonly ILogger _log = new LoggerConfiguration().MinimumLevel.Is(LevelAlias.Off).CreateLogger();
     readonly Exception _exception = new();
+    readonly ActivitySource _activitySource = new(nameof(LoggerActivityLeveledOffBenchmarks));
+
+    [Benchmark(Baseline = true)]
+    public Activity? ActivitySourceBaseline()
+    {
+        var activity = _activitySource.StartActivity();
+        activity?.Dispose();
+        return activity;
+    }
 
     [Benchmark]
     public LoggerActivity StartThenDispose()
@@ -28,5 +38,10 @@ public class LoggerActivityLeveledOffBenchmarks
         var activity = _log.StartActivity("Benchmark");
         activity.Complete(LogEventLevel.Error, _exception);
         return activity;
+    }
+
+    public void Dispose()
+    {
+        _activitySource.Dispose();
     }
 }

--- a/test/SerilogTracing.Benchmarks/LoggerActivitySampledOffBenchmarks.cs
+++ b/test/SerilogTracing.Benchmarks/LoggerActivitySampledOffBenchmarks.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using Serilog;
+using Serilog.Events;
+
+namespace SerilogTracing.Benchmarks;
+
+/// <summary>
+/// These benchmarks cover usage when the intended span is fully captured, in an application that uses full-featured
+/// tracing.
+/// </summary>
+[MemoryDiagnoser]
+public class LoggerActivitySampledOffBenchmarks: IDisposable
+{
+    readonly ILogger _log = new LoggerConfiguration().MinimumLevel.Is(LevelAlias.Minimum).CreateLogger();
+    readonly Exception _exception = new();
+    readonly IDisposable _activityListener;
+
+    public LoggerActivitySampledOffBenchmarks()
+    {
+        _activityListener = new ActivityListenerConfiguration()
+            .Instrument.WithDefaultInstrumentation(false)
+            .Sample.Using((ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.None)
+            .TraceTo(_log);
+    }
+
+    [Benchmark]
+    public LoggerActivity StartThenDispose()
+    {
+        var activity = _log.StartActivity("Benchmark");
+        activity.Dispose();
+        return activity;
+    }
+    
+    [Benchmark]
+    public LoggerActivity StartThenComplete()
+    {
+        var activity = _log.StartActivity("Benchmark");
+        activity.Complete(LogEventLevel.Error, _exception);
+        return activity;
+    }
+
+    public void Dispose()
+    {
+        _activityListener.Dispose();
+    }
+}

--- a/test/SerilogTracing.Benchmarks/LoggerActivityTracingNotConfiguredBenchmarks.cs
+++ b/test/SerilogTracing.Benchmarks/LoggerActivityTracingNotConfiguredBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using Serilog;
+using Serilog.Events;
+
+namespace SerilogTracing.Benchmarks;
+
+/// <summary>
+/// These benchmarks cover usage when tracing is not configured; activities are always created in these cases.
+/// </summary>
+[MemoryDiagnoser]
+public class LoggerActivityTracingNotConfiguredBenchmarks
+{
+    readonly ILogger _log = new LoggerConfiguration().MinimumLevel.Is(LevelAlias.Minimum).CreateLogger();
+    readonly Exception _exception = new();
+    
+    [Benchmark]
+    public LoggerActivity StartThenDispose()
+    {
+        var activity = _log.StartActivity("Benchmark");
+        activity.Dispose();
+        return activity;
+    }
+    
+    [Benchmark]
+    public LoggerActivity StartThenComplete()
+    {
+        var activity = _log.StartActivity("Benchmark");
+        activity.Complete(LogEventLevel.Error, _exception);
+        return activity;
+    }
+}

--- a/test/SerilogTracing.Benchmarks/LoggerActivityTracingOnBenchmarks.cs
+++ b/test/SerilogTracing.Benchmarks/LoggerActivityTracingOnBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
 using Serilog;
 using Serilog.Events;
@@ -14,12 +15,21 @@ public class LoggerActivityTracingOnBenchmarks: IDisposable
     readonly ILogger _log = new LoggerConfiguration().MinimumLevel.Is(LevelAlias.Minimum).CreateLogger();
     readonly Exception _exception = new();
     readonly IDisposable _activityListener;
+    readonly ActivitySource _activitySource = new(nameof(LoggerActivityTracingOnBenchmarks));
 
     public LoggerActivityTracingOnBenchmarks()
     {
         _activityListener = new ActivityListenerConfiguration()
             .Instrument.WithDefaultInstrumentation(false)
             .TraceTo(_log);
+    }
+    
+    [Benchmark(Baseline = true)]
+    public Activity? ActivitySourceBaseline()
+    {
+        var activity = _activitySource.StartActivity();
+        activity?.Dispose();
+        return activity;
     }
 
     [Benchmark]
@@ -41,5 +51,6 @@ public class LoggerActivityTracingOnBenchmarks: IDisposable
     public void Dispose()
     {
         _activityListener.Dispose();
+        _activitySource.Dispose();
     }
 }

--- a/test/SerilogTracing.Benchmarks/LoggerActivityTracingOnBenchmarks.cs
+++ b/test/SerilogTracing.Benchmarks/LoggerActivityTracingOnBenchmarks.cs
@@ -24,7 +24,7 @@ public class LoggerActivityTracingOnBenchmarks: IDisposable
         _loggerActivityListener = new ActivityListenerConfiguration()
             .InitialLevel.Override(_ignoredSource.Name, LogEventLevel.Verbose)
             .Instrument.WithDefaultInstrumentation(false)
-            .TraceTo(_log, ignoreLevelChanges: true);
+            .TraceTo(_log);
 
         _ignoringActivityListener = new ActivityListener();
         _ignoringActivityListener.ShouldListenTo = source => source == _ignoredSource;

--- a/test/SerilogTracing.Benchmarks/LoggerActivityTracingOnBenchmarks.cs
+++ b/test/SerilogTracing.Benchmarks/LoggerActivityTracingOnBenchmarks.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Attributes;
+using Serilog;
+using Serilog.Events;
+
+namespace SerilogTracing.Benchmarks;
+
+/// <summary>
+/// These benchmarks cover usage when the intended span is fully captured, in an application that uses full-featured
+/// tracing.
+/// </summary>
+[MemoryDiagnoser]
+public class LoggerActivityTracingOnBenchmarks: IDisposable
+{
+    readonly ILogger _log = new LoggerConfiguration().MinimumLevel.Is(LevelAlias.Minimum).CreateLogger();
+    readonly Exception _exception = new();
+    readonly IDisposable _activityListener;
+
+    public LoggerActivityTracingOnBenchmarks()
+    {
+        _activityListener = new ActivityListenerConfiguration()
+            .Instrument.WithDefaultInstrumentation(false)
+            .TraceTo(_log);
+    }
+
+    [Benchmark]
+    public LoggerActivity StartThenDispose()
+    {
+        var activity = _log.StartActivity("Benchmark");
+        activity.Dispose();
+        return activity;
+    }
+    
+    [Benchmark]
+    public LoggerActivity StartThenComplete()
+    {
+        var activity = _log.StartActivity("Benchmark");
+        activity.Complete(LogEventLevel.Error, _exception);
+        return activity;
+    }
+
+    public void Dispose()
+    {
+        _activityListener.Dispose();
+    }
+}

--- a/test/SerilogTracing.Benchmarks/Program.cs
+++ b/test/SerilogTracing.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+﻿using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/test/SerilogTracing.Benchmarks/SerilogTracing.Benchmarks.csproj
+++ b/test/SerilogTracing.Benchmarks/SerilogTracing.Benchmarks.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>net48;net8.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\SerilogTracing\SerilogTracing.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/SerilogTracing.Instrumentation.AspNetCore.Tests/SerilogTracing.Instrumentation.AspNetCore.Tests.csproj
+++ b/test/SerilogTracing.Instrumentation.AspNetCore.Tests/SerilogTracing.Instrumentation.AspNetCore.Tests.csproj
@@ -4,8 +4,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <SignAssembly>true</SignAssembly>
-        <AssemblyOriginatorKeyFile>../../assets/SerilogTracing.snk</AssemblyOriginatorKeyFile>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>

--- a/test/SerilogTracing.Instrumentation.SqlClient.Tests/SerilogTracing.Instrumentation.SqlClient.Tests.csproj
+++ b/test/SerilogTracing.Instrumentation.SqlClient.Tests/SerilogTracing.Instrumentation.SqlClient.Tests.csproj
@@ -4,8 +4,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <SignAssembly>true</SignAssembly>
-        <AssemblyOriginatorKeyFile>../../assets/SerilogTracing.snk</AssemblyOriginatorKeyFile>
         <IsPackable>false</IsPackable>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -6,7 +6,7 @@ namespace SerilogTracing
         public SerilogTracing.Configuration.ActivityListenerInitialLevelConfiguration InitialLevel { get; }
         public SerilogTracing.Configuration.ActivityListenerInstrumentationConfiguration Instrument { get; }
         public SerilogTracing.Configuration.ActivityListenerSamplingConfiguration Sample { get; }
-        public System.IDisposable TraceTo(Serilog.ILogger logger) { }
+        public System.IDisposable TraceTo(Serilog.ILogger logger, bool ignoreLevelChanges = false) { }
         public System.IDisposable TraceToSharedLogger() { }
     }
     public static class ActivityListenerInstrumentationConfigurationHttpClientExtensions

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -6,7 +6,7 @@ namespace SerilogTracing
         public SerilogTracing.Configuration.ActivityListenerInitialLevelConfiguration InitialLevel { get; }
         public SerilogTracing.Configuration.ActivityListenerInstrumentationConfiguration Instrument { get; }
         public SerilogTracing.Configuration.ActivityListenerSamplingConfiguration Sample { get; }
-        public System.IDisposable TraceTo(Serilog.ILogger logger, bool ignoreLevelChanges = false) { }
+        public System.IDisposable TraceTo(Serilog.ILogger logger) { }
         public System.IDisposable TraceToSharedLogger() { }
     }
     public static class ActivityListenerInstrumentationConfigurationHttpClientExtensions

--- a/test/SerilogTracing.Sinks.OpenTelemetry.Tests/SerilogTracing.Sinks.OpenTelemetry.Tests.csproj
+++ b/test/SerilogTracing.Sinks.OpenTelemetry.Tests/SerilogTracing.Sinks.OpenTelemetry.Tests.csproj
@@ -8,8 +8,6 @@
     <LangVersion>12</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\assets\SerilogTracing.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/test/SerilogTracing.Tests/Benchmarks/LoggerActivityLeveledOffBenchmarksTests.cs
+++ b/test/SerilogTracing.Tests/Benchmarks/LoggerActivityLeveledOffBenchmarksTests.cs
@@ -1,0 +1,28 @@
+using SerilogTracing.Benchmarks;
+using Xunit;
+
+namespace SerilogTracing.Tests.Benchmarks;
+
+[Collection("Shared")]
+public class LoggerActivityLeveledOffBenchmarksTests
+{
+    [Fact]
+    public void LeveledOffStartThenDispose()
+    {
+        var benchmarks = new LoggerActivityLeveledOffBenchmarks();
+        var activity = benchmarks.StartThenDispose();
+        Assert.NotNull(activity);
+        Assert.Same(LoggerActivity.None, activity);
+        Assert.Null(activity.Activity);
+    }
+    
+    [Fact]
+    public void LeveledOffStartThenComplete()
+    {
+        var benchmarks = new LoggerActivityLeveledOffBenchmarks();
+        var activity = benchmarks.StartThenComplete();
+        Assert.NotNull(activity);
+        Assert.Same(LoggerActivity.None, activity);
+        Assert.Null(activity.Activity);
+    }
+}

--- a/test/SerilogTracing.Tests/Benchmarks/LoggerActivityLeveledOffBenchmarksTests.cs
+++ b/test/SerilogTracing.Tests/Benchmarks/LoggerActivityLeveledOffBenchmarksTests.cs
@@ -7,6 +7,14 @@ namespace SerilogTracing.Tests.Benchmarks;
 public class LoggerActivityLeveledOffBenchmarksTests
 {
     [Fact]
+    public void ActivitySourceBaseline()
+    {
+        var benchmarks = new LoggerActivityLeveledOffBenchmarks();
+        var activity = benchmarks.ActivitySourceBaseline();
+        Assert.Null(activity);
+    }
+    
+    [Fact]
     public void LeveledOffStartThenDispose()
     {
         var benchmarks = new LoggerActivityLeveledOffBenchmarks();

--- a/test/SerilogTracing.Tests/Benchmarks/LoggerActivitySampledOffBenchmarksTests.cs
+++ b/test/SerilogTracing.Tests/Benchmarks/LoggerActivitySampledOffBenchmarksTests.cs
@@ -1,0 +1,28 @@
+using SerilogTracing.Benchmarks;
+using Xunit;
+
+namespace SerilogTracing.Tests.Benchmarks;
+
+[Collection("Shared")]
+public class LoggerActivitySampledOffBenchmarksTests
+{
+    [Fact]
+    public void SampledOffStartThenDispose()
+    {
+        var benchmarks = new LoggerActivityLeveledOffBenchmarks();
+        var activity = benchmarks.StartThenDispose();
+        Assert.NotNull(activity);
+        Assert.Same(LoggerActivity.None, activity);
+        Assert.Null(activity.Activity);
+    }
+    
+    [Fact]
+    public void SampledOffStartThenComplete()
+    {
+        var benchmarks = new LoggerActivityLeveledOffBenchmarks();
+        var activity = benchmarks.StartThenComplete();
+        Assert.NotNull(activity);
+        Assert.Same(LoggerActivity.None, activity);
+        Assert.Null(activity.Activity);
+    }
+}

--- a/test/SerilogTracing.Tests/Benchmarks/LoggerActivityTracingNotConfiguredBenchmarksTests.cs
+++ b/test/SerilogTracing.Tests/Benchmarks/LoggerActivityTracingNotConfiguredBenchmarksTests.cs
@@ -1,0 +1,30 @@
+using SerilogTracing.Benchmarks;
+using Xunit;
+
+namespace SerilogTracing.Tests.Benchmarks;
+
+[Collection("Shared")]
+public class LoggerActivityTracingNotConfiguredBenchmarksTests
+{
+    [Fact]
+    public void TracingNotConfiguredStartThenDispose()
+    {
+        var benchmarks = new LoggerActivityTracingNotConfiguredBenchmarks();
+        var activity = benchmarks.StartThenDispose();
+        Assert.NotNull(activity);
+        Assert.NotSame(LoggerActivity.None, activity);
+        Assert.NotNull(activity.Activity);
+        Assert.Equal("", activity.Activity.Source.Name);
+    }
+
+    [Fact]
+    public void TracingNotConfiguredStartThenComplete()
+    {
+        var benchmarks = new LoggerActivityTracingNotConfiguredBenchmarks();
+        var activity = benchmarks.StartThenComplete();
+        Assert.NotNull(activity);
+        Assert.NotSame(LoggerActivity.None, activity);
+        Assert.NotNull(activity.Activity);
+        Assert.Equal("", activity.Activity.Source.Name);
+    }
+}

--- a/test/SerilogTracing.Tests/Benchmarks/LoggerActivityTracingOnBenchmarksTests.cs
+++ b/test/SerilogTracing.Tests/Benchmarks/LoggerActivityTracingOnBenchmarksTests.cs
@@ -12,6 +12,16 @@ public class LoggerActivityTracingOnBenchmarksTests
         var benchmarks = new LoggerActivityTracingOnBenchmarks();
         var activity = benchmarks.ActivitySourceBaseline();
         Assert.NotNull(activity);
+        // Would be nice to assert effect on the logging pipeline here.
+    }
+
+    [Fact]
+    public void ActivityListenerOnly()
+    {
+        var benchmarks = new LoggerActivityTracingOnBenchmarks();
+        var activity = benchmarks.ActivityListenerOnly();
+        Assert.NotNull(activity);
+        // Would be nice to assert effect on the logging pipeline here.
     }
 
     [Fact]

--- a/test/SerilogTracing.Tests/Benchmarks/LoggerActivityTracingOnBenchmarksTests.cs
+++ b/test/SerilogTracing.Tests/Benchmarks/LoggerActivityTracingOnBenchmarksTests.cs
@@ -7,6 +7,14 @@ namespace SerilogTracing.Tests.Benchmarks;
 public class LoggerActivityTracingOnBenchmarksTests
 {
     [Fact]
+    public void ActivitySourceBaseline()
+    {
+        var benchmarks = new LoggerActivityTracingOnBenchmarks();
+        var activity = benchmarks.ActivitySourceBaseline();
+        Assert.NotNull(activity);
+    }
+
+    [Fact]
     public void TracingOnStartThenDispose()
     {
         var benchmarks = new LoggerActivityTracingOnBenchmarks();

--- a/test/SerilogTracing.Tests/Benchmarks/LoggerActivityTracingOnBenchmarksTests.cs
+++ b/test/SerilogTracing.Tests/Benchmarks/LoggerActivityTracingOnBenchmarksTests.cs
@@ -1,0 +1,30 @@
+using SerilogTracing.Benchmarks;
+using Xunit;
+
+namespace SerilogTracing.Tests.Benchmarks;
+
+[Collection("Shared")]
+public class LoggerActivityTracingOnBenchmarksTests
+{
+    [Fact]
+    public void TracingOnStartThenDispose()
+    {
+        var benchmarks = new LoggerActivityTracingOnBenchmarks();
+        var activity = benchmarks.StartThenDispose();
+        Assert.NotNull(activity);
+        Assert.NotSame(LoggerActivity.None, activity);
+        Assert.NotNull(activity.Activity);
+        Assert.Equal(Core.Constants.SerilogTracingActivitySourceName, activity.Activity.Source.Name);
+    }
+
+    [Fact]
+    public void TracingOnStartThenComplete()
+    {
+        var benchmarks = new LoggerActivityTracingOnBenchmarks();
+        var activity = benchmarks.StartThenComplete();
+        Assert.NotNull(activity);
+        Assert.NotSame(LoggerActivity.None, activity);
+        Assert.NotNull(activity.Activity);
+        Assert.Equal(Core.Constants.SerilogTracingActivitySourceName, activity.Activity.Source.Name);
+    }
+}

--- a/test/SerilogTracing.Tests/PackagingTests.cs
+++ b/test/SerilogTracing.Tests/PackagingTests.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace SerilogTracing.Tests;
+
+public class PackagingTests
+{
+    [Fact]
+    public void SerilogTracingAssemblyIsSigned()
+    {
+        var assemblyName = typeof(ActivityListenerConfiguration).Assembly.GetName();
+        var token = assemblyName.GetPublicKeyToken();
+        Assert.NotNull(token);
+        Assert.NotEmpty(token);
+    }
+}

--- a/test/SerilogTracing.Tests/SerilogTracing.Tests.csproj
+++ b/test/SerilogTracing.Tests/SerilogTracing.Tests.csproj
@@ -4,8 +4,6 @@
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>../../assets/SerilogTracing.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
@@ -14,11 +12,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\SerilogTracing.Expressions\SerilogTracing.Expressions.csproj" />
     <ProjectReference Include="..\..\src\SerilogTracing\SerilogTracing.csproj" />
+    <ProjectReference Include="..\SerilogTracing.Benchmarks\SerilogTracing.Benchmarks.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
These should serve as a baseline against which we can asses changes in the future. They all focus on `StartActivity()` and `Complete()`/`Dispose()`, which right now seem likely to have the most prominent performance considerations.

There are four sets of benchmarks. In each, the `Complete()` variant is similar to the `Dispose()` one, but sets a level and exception.

## Leveled off

This one covers the common case of a span being suppressed by the level set on the target logger. The major costs will probably be around interface dispatch and the minimum level comparison. The `ActivitySource` version is only roughly comparable, since activity sources don't apply any level-like concept:

```
BenchmarkDotNet v0.13.12, macOS Sonoma 14.2.1 (23C71) [Darwin 23.2.0]
Apple M3 Pro, 1 CPU, 11 logical and 11 physical cores
.NET SDK 8.0.201
  [Host]     : .NET 8.0.2 (8.0.224.6711), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.2 (8.0.224.6711), Arm64 RyuJIT AdvSIMD
```

| Method                 | Mean      | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
|----------------------- |----------:|----------:|----------:|------:|--------:|----------:|------------:|
| ActivitySourceBaseline | 20.363 ns | 1.8095 ns | 5.2785 ns |  1.00 |    0.00 |         - |          NA |
| StartThenDispose       |  1.590 ns | 0.0009 ns | 0.0007 ns |  0.10 |    0.04 |         - |          NA |
| StartThenComplete      |  1.856 ns | 0.0007 ns | 0.0007 ns |  0.11 |    0.04 |         - |          NA |

> The baseline here seems to be much slower on my MBP than Linux desktop; will need to do some investigation but don't think it's blocking right now.

## Leveled on, tracing not configured

This usage is SerilogTracing in the simplified, local, SerilogTimings-like mode: the logging pipeline is used, but no activity listener is set up and so the spans are associated with `new Activity()` instances. This will be relevant for people migrating directly from SerilogTimings without (initially) enabling any additional tracing functionality.

| Method            | Mean     | Error   | StdDev  | Gen0   | Gen1   | Allocated |
|------------------ |---------:|--------:|--------:|-------:|-------:|----------:|
| StartThenDispose  | 280.7 ns | 0.57 ns | 0.50 ns | 0.1488 |      - |   1.22 KB |
| StartThenComplete | 620.0 ns | 0.48 ns | 0.37 ns | 0.2489 | 0.0010 |   2.04 KB |

## Sampled off

This usage covers fully-configured SerilogTracing with `System.Diagnostics.Activity` integration, but where sampling suppresses the intended span.

| Method            | Mean     | Error    | StdDev   | Gen0   | Allocated |
|------------------ |---------:|---------:|---------:|-------:|----------:|
| StartThenDispose  | 55.51 ns | 0.218 ns | 0.193 ns | 0.0162 |     136 B |
| StartThenComplete | 56.03 ns | 0.205 ns | 0.181 ns | 0.0162 |     136 B |

## Tracing on

Finally, the fully-configured, fully-enabled version.

The baseline `ActivitySourceBaseline` case is for a recorded `Activity` that reaches an `ActivityListener` that does nothing. This isn't functionally equivalent to the other cases but it's a useful yardstick of sorts anyway.

The `ActivityListenerOnly` case covers external activities generated outside SerilogTracing but recorded through its listener.

This benchmark sets `ignoreLevelChanges: true` in `TraceTo()`, which may be a useful optimization for Serilog deployments in which dynamic level control isn't used.

| Method                 | Mean     | Error   | StdDev  | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
|----------------------- |---------:|--------:|--------:|------:|-------:|-------:|----------:|------------:|
| A...SourceBaseline | 142.8 ns | 0.33 ns | 0.31 ns |  1.00 | 0.0496 |      - |     416 B |        1.00 |
| A...ListenerOnly   | 353.3 ns | 3.14 ns | 2.94 ns |  2.47 | 0.1564 | 0.0005 |    1312 B |        3.15 |
| S...Dispose       | 340.7 ns | 0.79 ns | 0.74 ns |  2.39 | 0.1488 |      - |    1248 B |        3.00 |
| S...Complete      | 677.9 ns | 1.54 ns | 1.36 ns |  4.75 | 0.2489 | 0.0010 |    2088 B |        5.02 |

Trimmed out some detail her to try to squeeze the table in without wrapping.