### PR TITLE
Mark WriteTo.SeqTracing() as obsolete; consumers should migrate to Serilog.Sinks.Seq 7.0.0+

### DIFF
--- a/example/Example.WeatherService/Example.WeatherService.csproj
+++ b/example/Example.WeatherService/Example.WeatherService.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="serilog.aspnetcore" Version="8.0.0" />
     <PackageReference Include="serilog" Version="3.1.1" />
     <PackageReference Include="serilog.sinks.console" Version="5.0.0" />
-    <ProjectReference Include="../../src/SerilogTracing/SerilogTracing.csproj" />
+    <PackageReference Include="serilog.sinks.seq" Version="7.0.0" />
     <ProjectReference Include="../../src/SerilogTracing.Expressions/SerilogTracing.Expressions.csproj" />
     <ProjectReference Include="../../src/SerilogTracing.Sinks.OpenTelemetry/SerilogTracing.Sinks.OpenTelemetry.csproj" />
     <ProjectReference Include="../../src/SerilogTracing.Sinks.Seq/SerilogTracing.Sinks.Seq.csproj" />

--- a/example/Example.WeatherService/Program.cs
+++ b/example/Example.WeatherService/Program.cs
@@ -9,7 +9,7 @@ using SerilogTracing.Sinks.OpenTelemetry;
 Log.Logger = new LoggerConfiguration()
     .Enrich.WithProperty("Application", typeof(Program).Assembly.GetName().Name)
     .WriteTo.Console(Formatters.CreateConsoleTextFormatter(TemplateTheme.Code))
-    .WriteTo.SeqTracing("http://localhost:5341")
+    .WriteTo.Seq("http://localhost:5341")
     .WriteTo.Zipkin("http://localhost:9411")
     .WriteTo.OpenTelemetry("http://localhost:5341/ingest/otlp/v1/logs", "http://localhost:5341/ingest/otlp/v1/traces", OtlpProtocol.HttpProtobuf, null, new Dictionary<string, object>()
     {

--- a/example/weather/Program.cs
+++ b/example/weather/Program.cs
@@ -8,7 +8,7 @@ using SerilogTracing.Sinks.OpenTelemetry;
 Log.Logger = new LoggerConfiguration()
     .Enrich.WithProperty("Application", typeof(Program).Assembly.GetName().Name)
     .WriteTo.Console(Formatters.CreateConsoleTextFormatter(TemplateTheme.Code))
-    .WriteTo.SeqTracing("http://localhost:5341")
+    .WriteTo.Seq("http://localhost:5341")
     .WriteTo.Zipkin("http://localhost:9411")
     .WriteTo.OpenTelemetry("http://localhost:5341/ingest/otlp/v1/logs", "http://localhost:5341/ingest/otlp/v1/traces", OtlpProtocol.HttpProtobuf, null, new Dictionary<string, object>()
     {

--- a/example/weather/weather.csproj
+++ b/example/weather/weather.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="serilog" Version="3.1.1" />
     <PackageReference Include="serilog.sinks.console" Version="5.0.0" />
-    <ProjectReference Include="../../src/SerilogTracing/SerilogTracing.csproj" />
+    <PackageReference Include="serilog.sinks.seq" Version="7.0.0" />
     <ProjectReference Include="../../src/SerilogTracing.Sinks.OpenTelemetry/SerilogTracing.Sinks.OpenTelemetry.csproj" />
     <ProjectReference Include="../../src/SerilogTracing.Sinks.Seq/SerilogTracing.Sinks.Seq.csproj" />
     <ProjectReference Include="../../src/SerilogTracing.Sinks.Zipkin/SerilogTracing.Sinks.Zipkin.csproj" />

--- a/src/SerilogTracing.Sinks.Seq/SeqTracingLoggerSinkConfigurationExtensions.cs
+++ b/src/SerilogTracing.Sinks.Seq/SeqTracingLoggerSinkConfigurationExtensions.cs
@@ -61,7 +61,7 @@ public static class SeqTracingLoggerSinkConfigurationExtensions
     /// <remarks>
     /// The functionality of this method is now provided by Serilog.Sinks.Seq version 7+.
     /// </remarks>
-    // Soon: [Obsolete("Use Serilog.Sinks.Seq version 7.0.0 or later, and WriteTo.Seq() instead.")]
+    [Obsolete("Use Serilog.Sinks.Seq version 7.0.0 or later, and WriteTo.Seq() instead.")]
     public static LoggerConfiguration SeqTracing(
       this LoggerSinkConfiguration loggerSinkConfiguration,
       string serverUrl,

--- a/src/SerilogTracing.Sinks.Seq/SerilogTracing.Sinks.Seq.csproj
+++ b/src/SerilogTracing.Sinks.Seq/SerilogTracing.Sinks.Seq.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
         <ProjectReference Include="..\SerilogTracing\SerilogTracing.csproj" />
         <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
-        <PackageReference Include="Serilog.Sinks.Seq" Version="7.0.0-*" />
+        <PackageReference Include="Serilog.Sinks.Seq" Version="7.0.0" />
     </ItemGroup>
 
 </Project>

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.Sinks.Seq.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.Sinks.Seq.approved.txt
@@ -2,6 +2,7 @@
 {
     public static class SeqTracingLoggerSinkConfigurationExtensions
     {
+        [System.Obsolete("Use Serilog.Sinks.Seq version 7.0.0 or later, and WriteTo.Seq() instead.")]
         public static Serilog.LoggerConfiguration SeqTracing(this Serilog.Configuration.LoggerSinkConfiguration loggerSinkConfiguration, string serverUrl, Serilog.Events.LogEventLevel restrictedToMinimumLevel = 0, int batchPostingLimit = 1000, System.TimeSpan? period = default, string? apiKey = null, string? bufferBaseFilename = null, long? bufferSizeLimitBytes = default, long? eventBodyLimitBytes = 262144, Serilog.Core.LoggingLevelSwitch? controlLevelSwitch = null, System.Net.Http.HttpMessageHandler? messageHandler = null, long? retainedInvalidPayloadsLimitBytes = default, int queueSizeLimit = 100000) { }
     }
 }


### PR DESCRIPTION
Once this has been merged to `dev` and a package published, we can remove the CSPROJ entirely.