### PR TITLE
Make the `HttpClient` instrumentation configurable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>12</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <VersionPrefix>1.0.1</VersionPrefix>
+        <VersionPrefix>1.1.0</VersionPrefix>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- The condition is required to support BenchmarkDotNet -->

--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentationOptions.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentationOptions.cs
@@ -18,7 +18,7 @@ using Serilog.Events;
 namespace SerilogTracing.Instrumentation.AspNetCore;
 
 /// <summary>
-/// Configuration for <see cref="HttpClient"/> HTTP request instrumentation.
+/// Configuration for ASP.NET Core HTTP request instrumentation.
 /// </summary>
 public sealed class HttpRequestInActivityInstrumentationOptions
 {

--- a/src/SerilogTracing/ActivityListenerInstrumentationConfigurationHttpClientExtensions.cs
+++ b/src/SerilogTracing/ActivityListenerInstrumentationConfigurationHttpClientExtensions.cs
@@ -23,10 +23,26 @@ namespace SerilogTracing;
 public static class ActivityListenerInstrumentationConfigurationHttpClientExtensions
 {
     /// <summary>
-    /// Add instrumentation for ASP.NET Core requests.
+    /// Add instrumentation for <see cref="HttpClient"/> requests.
     /// </summary>
+    /// <returns>Configuration object allowing method chaining.</returns>
     public static ActivityListenerConfiguration HttpClientRequests(this ActivityListenerInstrumentationConfiguration configuration)
     {
-        return configuration.With(new HttpRequestOutActivityInstrumentor());
+        return configuration.HttpClientRequests(_ => { });
+    }
+    
+    /// <summary>
+    /// Add instrumentation for <see cref="HttpClient"/> requests.
+    /// </summary>
+    /// <param name="configuration"></param>
+    /// <param name="configure">A callback to configure the instrumentation.</param>
+    /// <returns>Configuration object allowing method chaining.</returns>
+    public static ActivityListenerConfiguration HttpClientRequests(
+        this ActivityListenerInstrumentationConfiguration configuration, Action<HttpRequestOutActivityInstrumentationOptions> configure)
+    {
+        var httpOptions = new HttpRequestOutActivityInstrumentationOptions();
+        configure.Invoke(httpOptions);
+
+        return configuration.With(new HttpRequestOutActivityInstrumentor(httpOptions));
     }
 }

--- a/src/SerilogTracing/Configuration/ActivityListenerInstrumentationConfiguration.cs
+++ b/src/SerilogTracing/Configuration/ActivityListenerInstrumentationConfiguration.cs
@@ -26,7 +26,7 @@ public sealed class ActivityListenerInstrumentationConfiguration
     readonly List<IActivityInstrumentor> _instrumentors = [];
     bool _withDefaultInstrumentors = true;
 
-    static IEnumerable<IActivityInstrumentor> GetDefaultInstrumentors() => [new HttpRequestOutActivityInstrumentor()];
+    static IEnumerable<IActivityInstrumentor> GetDefaultInstrumentors() => [new HttpRequestOutActivityInstrumentor(new HttpRequestOutActivityInstrumentationOptions())];
 
     internal IEnumerable<IActivityInstrumentor> GetInstrumentors() =>
         _withDefaultInstrumentors ?

--- a/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentationOptions.cs
+++ b/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentationOptions.cs
@@ -47,7 +47,7 @@ public class HttpRequestOutActivityInstrumentationOptions
     static IEnumerable<LogEventProperty> DefaultGetResponseProperties(HttpResponseMessage? response) =>
         new[]
         {
-            new LogEventProperty("StatusCode", new ScalarValue(response?.StatusCode)),
+            new LogEventProperty("StatusCode", new ScalarValue(response?.StatusCode == null ? null : (int)response.StatusCode))
         };
 
     /// <summary>

--- a/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentationOptions.cs
+++ b/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentationOptions.cs
@@ -1,0 +1,76 @@
+// Copyright © SerilogTracing Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Events;
+
+namespace SerilogTracing.Instrumentation.HttpClient;
+
+/// <summary>
+/// Configuration for <see cref="HttpClient"/> HTTP request instrumentation.
+/// </summary>
+public class HttpRequestOutActivityInstrumentationOptions
+{
+    static bool DefaultIsErrorResponse(HttpResponseMessage response) => (int)response.StatusCode >= 400;
+    
+    const string DefaultRequestCompletionMessageTemplate = "HTTP {RequestMethod} {RequestUri}";
+
+    static IEnumerable<LogEventProperty> DefaultGetRequestProperties(HttpRequestMessage request)
+    {
+        // User, query, and fragment are trimmed by default to reduce information leakage.
+        
+        var uriBuilder = request.RequestUri == null ? null : new UriBuilder(request.RequestUri)
+        {
+            Query = null!,
+            Fragment = null!,
+            UserName = null!,
+            Password = null!
+        };
+
+        return new[]
+        {
+            new LogEventProperty("RequestMethod", new ScalarValue(request.Method)),
+            new LogEventProperty("RequestUri", new ScalarValue(uriBuilder?.Uri))
+        };
+    }
+
+    static IEnumerable<LogEventProperty> DefaultGetResponseProperties(HttpResponseMessage? response) =>
+        new[]
+        {
+            new LogEventProperty("StatusCode", new ScalarValue(response?.StatusCode)),
+        };
+
+    /// <summary>
+    /// The message template to associate with request activities.
+    /// </summary>
+    public string MessageTemplate { get; set; } = DefaultRequestCompletionMessageTemplate;
+
+    /// <summary>
+    /// A function to populate properties on the activity from an outgoing request.
+    /// </summary>
+    public Func<HttpRequestMessage, IEnumerable<LogEventProperty>> GetRequestProperties { get; set; } = DefaultGetRequestProperties;
+
+    /// <summary>
+    /// A function to populate properties on the activity from an incoming response.
+    /// </summary>
+    public Func<HttpResponseMessage?, IEnumerable<LogEventProperty>> GetResponseProperties { get; set; } = DefaultGetResponseProperties;
+    
+    /// <summary>
+    /// A callback that determines whether the given <see cref="HttpResponseMessage"/> is considered to be
+    /// an error. The default implementation returns <c langword="true" /> when the response status code
+    /// is greater than or equal to 400.
+    /// </summary>
+    /// <remarks>Requests that fail due to unhandled exceptions are always considered to have errored, and this callback
+    /// is ignored in those cases.</remarks>
+    public Func<HttpResponseMessage, bool> IsErrorResponse { get; set; } = DefaultIsErrorResponse;
+}

--- a/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/HttpClient/HttpRequestOutActivityInstrumentor.cs
@@ -21,14 +21,13 @@ namespace SerilogTracing.Instrumentation.HttpClient;
 /// <summary>
 /// An activity instrumentor that populates the current activity with context from outgoing HTTP requests.
 /// </summary>
-sealed class HttpRequestOutActivityInstrumentor : IActivityInstrumentor
+sealed class HttpRequestOutActivityInstrumentor(HttpRequestOutActivityInstrumentationOptions options) : IActivityInstrumentor
 {
     readonly PropertyAccessor<HttpRequestMessage> _requestAccessor = new("Request");
     readonly PropertyAccessor<TaskStatus> _requestTaskStatusAccessor = new("RequestTaskStatus");
     readonly PropertyAccessor<HttpResponseMessage> _responseAccessor = new("Response");
 
-    static readonly MessageTemplate MessageTemplateOverride =
-        new MessageTemplateParser().Parse("HTTP {RequestMethod} {RequestUri}");
+    readonly MessageTemplate _messageTemplateOverride = new MessageTemplateParser().Parse(options.MessageTemplate);
 
     /// <inheritdoc cref="IActivityInstrumentor.ShouldSubscribeTo"/>
     public bool ShouldSubscribeTo(string diagnosticListenerName)
@@ -49,25 +48,12 @@ sealed class HttpRequestOutActivityInstrumentor : IActivityInstrumentor
                     {
                         return;
                     }
+                    
+                    ActivityInstrumentation.SetMessageTemplateOverride(activity, _messageTemplateOverride);
+                    activity.DisplayName = _messageTemplateOverride.Text;
 
-                    // The message template and properties will need to be set through a configurable enrichment
-                    // mechanism, since the detail/information-leakage trade-off will be different for different
-                    // consumers.
-
-                    // For now, stripping any user, query, and fragment should be a reasonable default.
-
-                    var uriBuilder = new UriBuilder(request.RequestUri)
-                    {
-                        Query = null!,
-                        Fragment = null!,
-                        UserName = null!,
-                        Password = null!
-                    };
-
-                    ActivityInstrumentation.SetMessageTemplateOverride(activity, MessageTemplateOverride);
-                    activity.DisplayName = MessageTemplateOverride.Text;
-                    activity.AddTag("RequestUri", uriBuilder.Uri);
-                    activity.AddTag("RequestMethod", request.Method);
+                    var props = options.GetRequestProperties(request);
+                    ActivityInstrumentation.SetLogEventProperties(activity, props as LogEventProperty[] ?? props.ToArray());
                     break;
                 }
             case "System.Net.Http.HttpRequestOut.Stop":
@@ -77,12 +63,12 @@ sealed class HttpRequestOutActivityInstrumentor : IActivityInstrumentor
                         return;
                     }
 
-                    var statusCode = response != null ? (int?)response.StatusCode : null;
-                    ActivityInstrumentation.SetLogEventProperty(activity, new LogEventProperty("StatusCode", new ScalarValue(statusCode)));
+                    var props = options.GetResponseProperties(response);
+                    ActivityInstrumentation.SetLogEventProperties(activity, props as LogEventProperty[] ?? props.ToArray());
 
                     if (activity.Status == ActivityStatusCode.Unset)
                     {
-                        if (statusCode >= 400 ||
+                        if (response != null && options.IsErrorResponse(response) ||
                             _requestTaskStatusAccessor.TryGetValue(eventArgs, out var requestTaskStatus) && requestTaskStatus == TaskStatus.Faulted)
                         {
                             activity.SetStatus(ActivityStatusCode.Error);

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -12,6 +12,7 @@ namespace SerilogTracing
     public static class ActivityListenerInstrumentationConfigurationHttpClientExtensions
     {
         public static SerilogTracing.ActivityListenerConfiguration HttpClientRequests(this SerilogTracing.Configuration.ActivityListenerInstrumentationConfiguration configuration) { }
+        public static SerilogTracing.ActivityListenerConfiguration HttpClientRequests(this SerilogTracing.Configuration.ActivityListenerInstrumentationConfiguration configuration, System.Action<SerilogTracing.Instrumentation.HttpClient.HttpRequestOutActivityInstrumentationOptions> configure) { }
     }
     public sealed class LoggerActivity : System.IDisposable
     {
@@ -115,5 +116,16 @@ namespace SerilogTracing.Instrumentation
     {
         public PropertyAccessor(string propertyName) { }
         public bool TryGetValue(object receiver, out T? value) { }
+    }
+}
+namespace SerilogTracing.Instrumentation.HttpClient
+{
+    public class HttpRequestOutActivityInstrumentationOptions
+    {
+        public HttpRequestOutActivityInstrumentationOptions() { }
+        public System.Func<System.Net.Http.HttpRequestMessage, System.Collections.Generic.IEnumerable<Serilog.Events.LogEventProperty>> GetRequestProperties { get; set; }
+        public System.Func<System.Net.Http.HttpResponseMessage?, System.Collections.Generic.IEnumerable<Serilog.Events.LogEventProperty>> GetResponseProperties { get; set; }
+        public System.Func<System.Net.Http.HttpResponseMessage, bool> IsErrorResponse { get; set; }
+        public string MessageTemplate { get; set; }
     }
 }


### PR DESCRIPTION
```csharp
    .Instrument.WithDefaultInstrumentation(false)
    .Instrument.HttpClientRequests(opts => opts.MessageTemplate = "Hello, world!"); // etc.
```


![image](https://github.com/serilog-tracing/serilog-tracing/assets/342712/6d848992-0796-4081-8d41-0f58ac089dc8)

No breaking changes. I've kept with the pattern used in the ASP.NET Core request instrumentation, though we may wish to tweak some return types etc. there in the future to reduce allocation.

Via #96
