### PR TITLE
Don't consider aborted requests to have failed, but make this behavior visible and configurable

### DIFF
--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentationOptions.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentationOptions.cs
@@ -32,11 +32,19 @@ public sealed class HttpRequestInActivityInstrumentationOptions
             new LogEventProperty("RequestPath", new ScalarValue(request.Path)),
         };
 
-    static IEnumerable<LogEventProperty> DefaultGetResponseProperties(HttpResponse response) =>
-        new[]
+    static readonly LogEventProperty RequestAbortedTrue = new("RequestAborted", new ScalarValue(true));
+    static IEnumerable<LogEventProperty> DefaultGetResponseProperties(HttpResponse response)
+    {
+        var statusCode = new LogEventProperty("StatusCode", new ScalarValue(response.StatusCode));
+        return response.HttpContext.RequestAborted.IsCancellationRequested ? new []
         {
-            new LogEventProperty("StatusCode", new ScalarValue(response.StatusCode)),
-        };
+            statusCode,
+            RequestAbortedTrue,
+        } : [statusCode];
+    }
+
+    static bool DefaultIsErrorResponse(HttpResponse response) =>
+        response is { StatusCode: >= 500, HttpContext.RequestAborted.IsCancellationRequested: false };
 
     /// <summary>
     /// What distributed context to respect from incoming traceparent headers.
@@ -63,4 +71,10 @@ public sealed class HttpRequestInActivityInstrumentationOptions
     /// This closure will be invoked at the end of the request pipeline.
     /// </summary>
     public Func<HttpResponse, IEnumerable<LogEventProperty>> GetResponseProperties { get; set; } = DefaultGetResponseProperties;
+
+    /// <summary>
+    /// A callback to determine whether the given HTTP response indicates a failed request. The default returns
+    /// <c langword="true"/> if the status code is 500 or greater, and the request was not aborted.
+    /// </summary>
+    public Func<HttpResponse, bool> IsErrorResponse { get; set; } = DefaultIsErrorResponse;
 }

--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
@@ -33,14 +33,17 @@ sealed class HttpRequestInActivityInstrumentor : IActivityInstrumentor, IInstrum
         _getResponseProperties = options.GetResponseProperties;
         _messageTemplateOverride = new MessageTemplateParser().Parse(options.MessageTemplate);
         _incomingTraceParent = options.IncomingTraceParent;
+        _isErrorResponse = options.IsErrorResponse;
     }
 
     readonly Func<HttpRequest, IEnumerable<LogEventProperty>> _getRequestProperties;
     readonly Func<HttpResponse, IEnumerable<LogEventProperty>> _getResponseProperties;
     readonly MessageTemplate _messageTemplateOverride;
+    readonly Func<HttpResponse,bool> _isErrorResponse;
+    readonly IncomingTraceParent _incomingTraceParent;
+    
     readonly PropertyAccessor<Exception> _exceptionAccessor = new("exception");
     readonly PropertyAccessor<HttpContext> _httpContextAccessor = new("httpContext");
-    readonly IncomingTraceParent _incomingTraceParent;
 
     const string ReplacedActivityPropertyName = "SerilogTracing.Instrumentation.AspNetCore.Replaced";
     internal const string ReplacementActivitySourceName = "SerilogTracing.Instrumentation.AspNetCore";
@@ -86,8 +89,8 @@ sealed class HttpRequestInActivityInstrumentor : IActivityInstrumentor, IInstrum
             ActivityInstrumentation.SetMessageTemplateOverride(replacement, _messageTemplateOverride);
             replacement.DisplayName = _messageTemplateOverride.Text;
 
-            ActivityInstrumentation.SetLogEventProperties(replacement,
-                _getRequestProperties(start.Request).ToArray());
+            var props = _getRequestProperties(start.Request);
+            ActivityInstrumentation.SetLogEventProperties(replacement, props as LogEventProperty[] ?? props.ToArray());
 
             replacement.Start();
         }
@@ -110,10 +113,10 @@ sealed class HttpRequestInActivityInstrumentor : IActivityInstrumentor, IInstrum
             case "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop":
                 if (eventArgs is not HttpContext stop) return;
 
-                ActivityInstrumentation.SetLogEventProperties(activity,
-                    _getResponseProperties(stop.Response).ToArray());
+                var props = _getResponseProperties(stop.Response);
+                ActivityInstrumentation.SetLogEventProperties(activity, props as LogEventProperty[] ?? props.ToArray());
 
-                if (stop.Response.StatusCode >= 500)
+                if (_isErrorResponse(stop.Response))
                 {
                     activity.SetStatus(ActivityStatusCode.Error);
                 }

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.Instrumentation.AspNetCore.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.Instrumentation.AspNetCore.approved.txt
@@ -20,6 +20,7 @@ namespace SerilogTracing.Instrumentation.AspNetCore
         public System.Func<Microsoft.AspNetCore.Http.HttpRequest, System.Collections.Generic.IEnumerable<Serilog.Events.LogEventProperty>> GetRequestProperties { get; set; }
         public System.Func<Microsoft.AspNetCore.Http.HttpResponse, System.Collections.Generic.IEnumerable<Serilog.Events.LogEventProperty>> GetResponseProperties { get; set; }
         public SerilogTracing.IncomingTraceParent IncomingTraceParent { get; set; }
+        public System.Func<Microsoft.AspNetCore.Http.HttpResponse, bool> IsErrorResponse { get; set; }
         public string MessageTemplate { get; set; }
     }
 }


### PR DESCRIPTION
Via #96

No breaking changes.