### PR TITLE
Configurable `SqlClient` instrumentation

### DIFF
--- a/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentationOptions.cs
+++ b/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentationOptions.cs
@@ -66,6 +66,10 @@ public sealed class SqlCommandActivityInstrumentationOptions
     /// A function to populate properties on the activity from an executing <see cref="SqlCommand"/>. The callback
     /// runs before the command is executed.
     /// </summary>
+    /// <remarks>
+    /// When providing this setting, if the default properties are still required, keep a reference to the original
+    /// (default) property value and call it from within the new replacement callback.
+    /// </remarks>
     public Func<SqlCommand, IEnumerable<LogEventProperty>> GetCommandProperties { get; set; }
 
     /// <summary>
@@ -77,6 +81,7 @@ public sealed class SqlCommandActivityInstrumentationOptions
     /// <summary>
     /// Include the command text (i.e. the stored procedure name, SQL statement, or table name) in spans. The risk
     /// of exposing sensitive data, and bloating span size, means that the default value is <c langword="false"/>.
+    /// Ignored if <see cref="GetCommandProperties"/> is specified and does not chain calls to the default value.
     /// </summary>
     public bool IncludeCommandText { get; set; } = false;
 
@@ -84,6 +89,7 @@ public sealed class SqlCommandActivityInstrumentationOptions
     /// Attempt to infer the operation (<c>SELECT</c>, <c>INSERT</c>, <c>UPDATE</c>, <c>DELETE</c>, or <c>EXEC</c>)
     /// by inspecting the command text. The inferred value may be incorrect in some cases as only very limited command
     /// parsing is performed. The default is <c langword="true"/>.
+    /// Ignored if <see cref="GetCommandProperties"/> is specified and does not chain calls to the default value.
     /// </summary>
     public bool InferOperation { get; set; } = true;
 }

--- a/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentationOptions.cs
+++ b/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentationOptions.cs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections;
 using Microsoft.Data.SqlClient;
+using Serilog.Events;
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
 
 namespace SerilogTracing.Instrumentation.SqlClient;
 
@@ -21,6 +25,55 @@ namespace SerilogTracing.Instrumentation.SqlClient;
 /// </summary>
 public sealed class SqlCommandActivityInstrumentationOptions
 {
+    const string DefaultCommandMessageTemplate = "SQL {Operation} {Database}";
+
+    /// <summary>
+    /// Construct a <see cref="SqlCommandActivityInstrumentationOptions"/>.
+    /// </summary>
+    public SqlCommandActivityInstrumentationOptions()
+    {
+        GetCommandProperties = DefaultGetCommandProperties;
+    }
+
+    IEnumerable<LogEventProperty> DefaultGetCommandProperties(SqlCommand command)
+    {
+        var database = new LogEventProperty("Database", new ScalarValue(command.Connection.Database));
+        var operation = new LogEventProperty("Operation", new ScalarValue(SqlCommandInspector.GetOperation(command, InferOperation)));
+
+        return IncludeCommandText
+            ? [database, operation, new LogEventProperty("CommandText", new ScalarValue(command.CommandText))]
+            : [database, operation];
+    }
+
+    static IEnumerable<LogEventProperty> DefaultGetStatisticsProperties(IDictionary statistics)
+    {
+        // See https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql/provider-statistics-for-sql-server
+        var networkServerTimeMilliseconds = statistics["NetworkServerTime"];
+        if (networkServerTimeMilliseconds != null)
+        {
+            return [new LogEventProperty("NetworkServerTime", new ScalarValue(networkServerTimeMilliseconds))];
+        }
+
+        return [];
+    }
+    
+    /// <summary>
+    /// The message template to associate with command activities.
+    /// </summary>
+    public string MessageTemplate { get; set; } = DefaultCommandMessageTemplate;
+
+    /// <summary>
+    /// A function to populate properties on the activity from an executing <see cref="SqlCommand"/>. The callback
+    /// runs before the command is executed.
+    /// </summary>
+    public Func<SqlCommand, IEnumerable<LogEventProperty>> GetCommandProperties { get; set; }
+
+    /// <summary>
+    /// A function to populate properties on the activity from command statistics. The callback
+    /// runs after the command is executed.
+    /// </summary>
+    public Func<IDictionary, IEnumerable<LogEventProperty>> GetStatisticsProperties { get; set; } = DefaultGetStatisticsProperties;
+
     /// <summary>
     /// Include the command text (i.e. the stored procedure name, SQL statement, or table name) in spans. The risk
     /// of exposing sensitive data, and bloating span size, means that the default value is <c langword="false"/>.

--- a/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentor.cs
+++ b/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandActivityInstrumentor.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Collections;
-using System.Data;
 using System.Diagnostics;
 using Microsoft.Data.SqlClient;
 using Serilog.Events;
@@ -27,7 +26,7 @@ sealed class SqlCommandActivityInstrumentor(SqlCommandActivityInstrumentationOpt
 
     static readonly ActivitySource ActivitySource = new("SerilogTracing.Instrumentation.SqlClient");
 
-    readonly MessageTemplate _messageTemplateOverride = new MessageTemplateParser().Parse("SQL {Operation} {Database}");
+    readonly MessageTemplate _messageTemplateOverride = new MessageTemplateParser().Parse(options.MessageTemplate);
     readonly PropertyAccessor<SqlCommand> _getCommand = new("Command");
     readonly PropertyAccessor<Exception> _getException = new("Exception");
     readonly PropertyAccessor<IDictionary> _getStatistics = new("Statistics");
@@ -67,16 +66,8 @@ sealed class SqlCommandActivityInstrumentor(SqlCommandActivityInstrumentationOpt
 
                     if (_getCommand.TryGetValue(eventArgs, out var command) && command is not null)
                     {
-                        var database = command.Connection.Database;
-                        var operation = GetOperation(command, options.InferOperation);
-                        ActivityInstrumentation.SetLogEventProperties(child,
-                            new LogEventProperty("Operation", new ScalarValue(operation)),
-                            new LogEventProperty("Database", new ScalarValue(database)));
-
-                        if (options.IncludeCommandText)
-                        {
-                            ActivityInstrumentation.SetLogEventProperty(child, new LogEventProperty("CommandText", new ScalarValue(command.CommandText)));
-                        }
+                        var props = options.GetCommandProperties(command);
+                        ActivityInstrumentation.SetLogEventProperties(child, props as LogEventProperty[] ?? props.ToArray());
                     }
 
                     break;
@@ -92,13 +83,8 @@ sealed class SqlCommandActivityInstrumentor(SqlCommandActivityInstrumentationOpt
 
                     if (activity.IsAllDataRequested && _getStatistics.TryGetValue(eventArgs, out var statistics) && statistics is not null)
                     {
-                        // See https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql/provider-statistics-for-sql-server
-                        var networkServerTimeMilliseconds = statistics["NetworkServerTime"];
-                        if (networkServerTimeMilliseconds != null)
-                        {
-                            var property = new LogEventProperty("NetworkServerTime", new ScalarValue(networkServerTimeMilliseconds));
-                            ActivityInstrumentation.SetLogEventProperty(activity, property);
-                        }
+                        var props = options.GetStatisticsProperties(statistics);
+                        ActivityInstrumentation.SetLogEventProperties(activity, props as LogEventProperty[] ?? props.ToArray());
                     }
 
                     activity.Stop();
@@ -127,18 +113,5 @@ sealed class SqlCommandActivityInstrumentor(SqlCommandActivityInstrumentationOpt
                     break;
                 }
         }
-    }
-
-    static string GetOperation(SqlCommand command, bool inferOperationFromCommandText)
-    {
-        if (command.CommandType == CommandType.StoredProcedure)
-            return "EXEC";
-
-        if (command.CommandType == CommandType.TableDirect)
-            return "DIRECT";
-
-        return inferOperationFromCommandText ?
-            CommandTextTokenizer.FindFirstOperation(command.CommandText) ?? "BATCH" :
-            "BATCH";
     }
 }

--- a/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandInspector.cs
+++ b/src/SerilogTracing.Instrumentation.SqlClient/Instrumentation/SqlClient/SqlCommandInspector.cs
@@ -1,0 +1,34 @@
+// Copyright © SerilogTracing Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Data;
+using Microsoft.Data.SqlClient;
+
+namespace SerilogTracing.Instrumentation.SqlClient;
+
+static class SqlCommandInspector
+{
+    public static string GetOperation(SqlCommand command, bool inferOperationFromCommandText)
+    {
+        if (command.CommandType == CommandType.StoredProcedure)
+            return "EXEC";
+
+        if (command.CommandType == CommandType.TableDirect)
+            return "DIRECT";
+
+        return inferOperationFromCommandText ?
+            CommandTextTokenizer.FindFirstOperation(command.CommandText) ?? "BATCH" :
+            "BATCH";
+    }
+}

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.Instrumentation.SqlClient.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.Instrumentation.SqlClient.approved.txt
@@ -11,7 +11,10 @@ namespace SerilogTracing.Instrumentation.SqlClient
     public sealed class SqlCommandActivityInstrumentationOptions
     {
         public SqlCommandActivityInstrumentationOptions() { }
+        public System.Func<Microsoft.Data.SqlClient.SqlCommand, System.Collections.Generic.IEnumerable<Serilog.Events.LogEventProperty>> GetCommandProperties { get; set; }
+        public System.Func<System.Collections.IDictionary, System.Collections.Generic.IEnumerable<Serilog.Events.LogEventProperty>> GetStatisticsProperties { get; set; }
         public bool IncludeCommandText { get; set; }
         public bool InferOperation { get; set; }
+        public string MessageTemplate { get; set; }
     }
 }


### PR DESCRIPTION
Adds `options.MessageTemplate`, and two callbacks to control population of properties from the command (pre-execution) and post-execution statistics.

Fixes #100 
Fixes #102