### PR TITLE
Use the new `LoggerSinkConfiguration.CreateSink()` method to avoid the "wrap hack"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.201",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }

--- a/src/SerilogTracing.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
+++ b/src/SerilogTracing.Sinks.OpenTelemetry/OpenTelemetryLoggerConfigurationExtensions.cs
@@ -67,12 +67,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
                 resourceAttributes: new Dictionary<string, object>(options.ResourceAttributes),
                 includedData: options.IncludedData);
 
-            // The need for this pattern suggests we should wrap up something like it into a `GetSink()`...
-            LoggerSinkConfiguration.Wrap(new LoggerConfiguration().WriteTo, s =>
-            {
-                logsSink = s;
-                return s;
-            }, wt => wt.Sink(openTelemetryLogsSink, options.BatchingOptions));
+            logsSink = LoggerSinkConfiguration.CreateSink(wt => wt.Sink(openTelemetryLogsSink, options.BatchingOptions));
         }
 
         if (options.TracesEndpoint != null)
@@ -82,11 +77,7 @@ public static class OpenTelemetryLoggerConfigurationExtensions
                 resourceAttributes: new Dictionary<string, object>(options.ResourceAttributes),
                 includedData: options.IncludedData);
 
-            LoggerSinkConfiguration.Wrap(new LoggerConfiguration().WriteTo, s =>
-            {
-                tracesSink = s;
-                return s;
-            }, wt => wt.Sink(openTelemetryTracesSink, options.BatchingOptions));
+            tracesSink = LoggerSinkConfiguration.CreateSink(wt => wt.Sink(openTelemetryTracesSink, options.BatchingOptions));
         }
 
         var sink = new OpenTelemetrySink(exporter, logsSink, tracesSink);

--- a/src/SerilogTracing.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
+++ b/src/SerilogTracing.Sinks.OpenTelemetry/Sinks/OpenTelemetry/OpenTelemetrySinkOptions.cs
@@ -30,11 +30,12 @@ public class OpenTelemetrySinkOptions
     internal const IncludedData DefaultIncludedData = IncludedData.MessageTemplateTextAttribute |
                                              IncludedData.TraceIdField | IncludedData.SpanIdField |
                                              IncludedData.SpecRequiredResourceAttributes;
-
+    
     /// <summary>
     /// The URL of the OTLP exporter logs endpoint.
     /// </summary>
     public string? LogsEndpoint { get; set; } = DefaultEndpoint;
+    
     /// <summary>
     /// The URL of the OTLP exporter traces endpoint.
     /// </summary>


### PR DESCRIPTION
This method, new in Serilog v4, lets us construct batching `ILogEventSink`s from the `IBatchedLogEventSink` implementations for logs and traces.