### PR TITLE
Record `HttpRequest.Path` as a `String` instead of `PathString`

### DIFF
--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentationOptions.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentationOptions.cs
@@ -29,7 +29,9 @@ public sealed class HttpRequestInActivityInstrumentationOptions
         new[]
         {
             new LogEventProperty("RequestMethod", new ScalarValue(request.Method)),
-            new LogEventProperty("RequestPath", new ScalarValue(request.Path)),
+            // `request.Path` is a `PathString` struct; we convert to `string` so that the resulting property value
+            // is easier to work with (i.e. in filter expressions).
+            new LogEventProperty("RequestPath", new ScalarValue(request.Path.ToString())),
         };
 
     static readonly LogEventProperty RequestAbortedTrue = new("RequestAborted", new ScalarValue(true));


### PR DESCRIPTION
Fixes #107 - `Serilog.Expressions` string operations rely on string-valued properties; when `RequestPath` is a `PathString`, all comparisons etc. are undefined.

Thanks @roberto-gaxiola for the report 😎 