### PR TITLE
Update to Serilog 4 RTM

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>12</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <VersionPrefix>1.1.0</VersionPrefix>
+        <VersionPrefix>2.0.0</VersionPrefix>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- The condition is required to support BenchmarkDotNet -->

--- a/src/SerilogTracing/SerilogTracing.csproj
+++ b/src/SerilogTracing/SerilogTracing.csproj
@@ -22,7 +22,7 @@
     <None Include="..\..\assets\icon.png" Pack="true" PackagePath="" Visible="false" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="4.0.0-*" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
     <InternalsVisibleTo Include="SerilogTracing.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a754c81a195a80e95b1638ebfa4d94281b4852f386a3de19794418f68acb0564da8a4ced775b1de531d640768186ceef422cdabb8c115055cf734971913672c4be1385d08902ef2a792786339725fb989d5cf64aea4e0703ee7d4e8b16426d8e6b61cb3479f33cdec568e2dd631f0fbb9f092702734a19e9964fadbd30bc619c" />
   </ItemGroup>
   


### PR DESCRIPTION
Updates the package version to 2.0.0, this was missed in #93, which should have included it.