### PR TITLE
SerilogTracing.Instrumentation.AspNetCore target .NET6 and .NET8

### DIFF
--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
@@ -171,7 +171,12 @@ sealed class HttpRequestInActivityInstrumentor : IActivityInstrumentor, IInstrum
 
             if (inheritTags)
             {
+
+#if FEATURE_ACTIVITY_ENUMERATETAGOBJECTS
+                foreach (var (name, value) in incoming.EnumerateTagObjects())
+#else
                 foreach (var (name, value) in incoming.TagObjects)
+#endif
                 {
                     replacement.SetTag(name, value);
                 }

--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentor.cs
@@ -171,7 +171,7 @@ sealed class HttpRequestInActivityInstrumentor : IActivityInstrumentor, IInstrum
 
             if (inheritTags)
             {
-                foreach (var (name, value) in incoming.EnumerateTagObjects())
+                foreach (var (name, value) in incoming.TagObjects)
                 {
                     replacement.SetTag(name, value);
                 }

--- a/src/SerilogTracing.Instrumentation.AspNetCore/SerilogTracing.Instrumentation.AspNetCore.csproj
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/SerilogTracing.Instrumentation.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+	    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>SerilogTracing</RootNamespace>
@@ -12,5 +12,9 @@
         <ProjectReference Include="..\SerilogTracing\SerilogTracing.csproj" />
         <InternalsVisibleTo Include="SerilogTracing.Instrumentation.AspNetCore.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a754c81a195a80e95b1638ebfa4d94281b4852f386a3de19794418f68acb0564da8a4ced775b1de531d640768186ceef422cdabb8c115055cf734971913672c4be1385d08902ef2a792786339725fb989d5cf64aea4e0703ee7d4e8b16426d8e6b61cb3479f33cdec568e2dd631f0fbb9f092702734a19e9964fadbd30bc619c" />
     </ItemGroup>
+
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+		<DefineConstants>$(DefineConstants);FEATURE_ACTIVITY_ENUMERATETAGOBJECTS</DefineConstants>
+	</PropertyGroup>
 
 </Project>

--- a/src/SerilogTracing.Instrumentation.AspNetCore/SerilogTracing.Instrumentation.AspNetCore.csproj
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/SerilogTracing.Instrumentation.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-	    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>SerilogTracing</RootNamespace>
@@ -13,8 +13,8 @@
         <InternalsVisibleTo Include="SerilogTracing.Instrumentation.AspNetCore.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a754c81a195a80e95b1638ebfa4d94281b4852f386a3de19794418f68acb0564da8a4ced775b1de531d640768186ceef422cdabb8c115055cf734971913672c4be1385d08902ef2a792786339725fb989d5cf64aea4e0703ee7d4e8b16426d8e6b61cb3479f33cdec568e2dd631f0fbb9f092702734a19e9964fadbd30bc619c" />
     </ItemGroup>
 
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<DefineConstants>$(DefineConstants);FEATURE_ACTIVITY_ENUMERATETAGOBJECTS</DefineConstants>
-	</PropertyGroup>
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+        <DefineConstants>$(DefineConstants);FEATURE_ACTIVITY_ENUMERATETAGOBJECTS</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/src/SerilogTracing.Instrumentation.AspNetCore/SerilogTracing.Instrumentation.AspNetCore.csproj
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/SerilogTracing.Instrumentation.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>SerilogTracing</RootNamespace>


### PR DESCRIPTION
Fixes #131 

- SerilogTracing.Instrumentation.AspNetCore now targets both .NET6 and .NET8
- Replaced the call to Activity.EnumerateTagObjects() because it is not available in .net6