### PR TITLE
Stop activities when not recorded

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -14,7 +14,7 @@ if(Test-Path .\artifacts) {
 
 & dotnet restore --no-cache
 
-$dbp = [Xml] (Get-Content .\Directory.Build.propsj)
+$dbp = [Xml] (Get-Content .\Directory.Build.props)
 $versionPrefix = $dbp.Project.PropertyGroup.VersionPrefix
 
 Write-Output "build: Package version prefix is $versionPrefix"

--- a/example/Sampling/Program.cs
+++ b/example/Sampling/Program.cs
@@ -1,0 +1,55 @@
+﻿using System.Diagnostics;
+using Serilog;
+using SerilogTracing;
+using SerilogTracing.Configuration;
+using SerilogTracing.Expressions;
+
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console(Formatters.CreateConsoleTextFormatter())
+    .CreateLogger();
+
+using var _ = new ActivityListenerConfiguration()
+    .Sample.Using(IntervalSampler.Create(7))
+    .TraceToSharedLogger();
+
+for (var i = 0; i < 10000; ++i)
+{
+    using var outer = Log.Logger.StartActivity("Outer {i}", i);
+    using var inner = Log.Logger.StartActivity("Inner {i}", i);
+    await Task.Delay(100);
+}
+
+static class IntervalSampler
+{
+    /// <summary>
+    /// Record one trace in every <paramref name="interval"/> possible traces.
+    /// </summary>
+    /// <param name="interval">The sampling interval. Note that this is per root activity, not per individual activity.</param>
+    /// <returns>A sampling function that can be provided to <see cref="ActivityListenerSamplingConfiguration.Using"/>.</returns>
+    public static SampleActivity<ActivityContext> Create(ulong interval)
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(interval);
+        var next = 0ul;
+        
+        return (ref ActivityCreationOptions<ActivityContext> options) =>
+        {
+            // The string comparison is required here because of some inconsistencies in how empty/default span ids
+            // are constructed.
+            if (options.Parent.SpanId.ToHexString() != default(ActivitySpanId).ToHexString())
+            {
+                // The activity is a child of another; if the parent is recorded, the child is recorded. Otherwise,
+                // there's no need to generate an activity at all.
+                return (options.Parent.TraceFlags & ActivityTraceFlags.Recorded) == ActivityTraceFlags.Recorded ?
+                    ActivitySamplingResult.AllDataAndRecorded :
+                    ActivitySamplingResult.None;
+            }
+
+            // We're at the root; if the trace is not included in the sample, return `PropagationData` so that
+            // we apply the same decision to child activities via the path above.
+            var n = Interlocked.Increment(ref next) % interval - 1;
+            return n == 0
+                ? ActivitySamplingResult.AllDataAndRecorded
+                : ActivitySamplingResult.PropagationData;
+        };
+    }
+}

--- a/example/Sampling/Sampling.csproj
+++ b/example/Sampling/Sampling.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\SerilogTracing.Expressions\SerilogTracing.Expressions.csproj" />
+      <ProjectReference Include="..\..\src\SerilogTracing\SerilogTracing.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="serilog.sinks.console" Version="6.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/serilog-tracing.sln
+++ b/serilog-tracing.sln
@@ -62,6 +62,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".workflows", ".workflows", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerilogTracing.Benchmarks", "test\SerilogTracing.Benchmarks\SerilogTracing.Benchmarks.csproj", "{9052EA54-5BEE-4203-8966-DEC013DE62CB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sampling", "example\Sampling\Sampling.csproj", "{C89D0546-587D-4504-8BC2-4E08D30ACE4F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +88,7 @@ Global
 		{0128EB76-9B60-4553-B089-2D1707CD0D65} = {92FDF45D-CCCD-4BEA-A5E3-CC8ECEF34472}
 		{ECE478F5-0719-4E59-8AEF-6AB12BE33B62} = {6BB7BDF8-8AEE-4D76-9E81-EA9984A66BF6}
 		{9052EA54-5BEE-4203-8966-DEC013DE62CB} = {92FDF45D-CCCD-4BEA-A5E3-CC8ECEF34472}
+		{C89D0546-587D-4504-8BC2-4E08D30ACE4F} = {E35D98E8-5F3C-4ABD-8A65-63B6E357DC2F}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2D5CE076-4A88-41C1-961B-A26ABA88E6F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -144,5 +147,9 @@ Global
 		{9052EA54-5BEE-4203-8966-DEC013DE62CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9052EA54-5BEE-4203-8966-DEC013DE62CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9052EA54-5BEE-4203-8966-DEC013DE62CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C89D0546-587D-4504-8BC2-4E08D30ACE4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C89D0546-587D-4504-8BC2-4E08D30ACE4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C89D0546-587D-4504-8BC2-4E08D30ACE4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C89D0546-587D-4504-8BC2-4E08D30ACE4F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
+++ b/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
@@ -19,10 +19,10 @@ public class LoggerTracingExtensionsTests
 
     [Theory]
     [InlineData(true, true, true, true)]
-    [InlineData(true, true, false, false)]
+    [InlineData(true, true, false, true)]
     [InlineData(true, false, null, true)]
     [InlineData(false, true, true, false)]
-    [InlineData(false, true, false, false)]
+    [InlineData(false, true, null, false)]
     [InlineData(false, false, null, false)]
     public void ActivityIsGeneratedWhen(bool levelEnabled, bool tracingEnabled, bool? includedInSample, bool activityExpected)
     {
@@ -50,7 +50,8 @@ public class LoggerTracingExtensionsTests
         var configuration = new ActivityListenerConfiguration();
         if (includedInSample is { } always)
         {
-            var result = always ? ActivitySamplingResult.AllData : ActivitySamplingResult.None;
+            var result = always ? ActivitySamplingResult.AllDataAndRecorded :
+                 ActivitySamplingResult.PropagationData;
             configuration.Sample.Using((ref ActivityCreationOptions<ActivityContext> _) => result);
         }
 


### PR DESCRIPTION
This PR includes a new example with a simple interval-based sampler. Running the sample showed up a bug in `LoggerActivity.Complete()`: an incorrect precondition prevented activities without the `Recorded` flag from being stopped, leading to incorrectly-suppressed traces.

The fix for this issue is the main purpose of the PR - with the sample included to make exploratory testing of sampling behavior easier in the future.