### PR TITLE
Include NUPKGs and symbols as GitHub release assets when publishing from `main`

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -72,6 +72,6 @@ if ($env:NUGET_API_KEY) {
     if (!($suffix)) {
         Write-Output "build: Creating release for version $versionPrefix"
 
-        gh release create "v$versionPrefix" --title "v$versionPrefix" --generate-notes
+        gh release create "v$versionPrefix" --title "v$versionPrefix" --generate-notes (get-item ./artifacts/*.nupkg) (get-item ./artifacts/*.snupkg)
     }
 }

--- a/Build.ps1
+++ b/Build.ps1
@@ -65,7 +65,7 @@ if ($env:NUGET_API_KEY) {
     Write-Output "build: Publishing NuGet packages"
     
     foreach ($nupkg in Get-ChildItem artifacts/*.nupkg) {
-        & dotnet nuget push -k $env:NUGET_API_KEY -s https://api.nuget.org/v3/index.json "$nupkg" --no-symbols
+        & dotnet nuget push -k $env:NUGET_API_KEY -s https://api.nuget.org/v3/index.json "$nupkg"
         if($LASTEXITCODE -ne 0) { throw "Publishing failed" }
     }
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -72,6 +72,6 @@ if ($env:NUGET_API_KEY) {
     if (!($suffix)) {
         Write-Output "build: Creating release for version $versionPrefix"
 
-        gh release create "v$versionPrefix" --title "v$versionPrefix" --generate-notes (get-item ./artifacts/*.nupkg) (get-item ./artifacts/*.snupkg)
+        gh release create "v$versionPrefix" --title "v$versionPrefix" --generate-notes @$"$(get-item ./artifacts/*.nupkg) $(get-item ./artifacts/*.snupkg)"
     }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,5 +10,7 @@
         <!-- The condition is required to support BenchmarkDotNet -->
         <SignAssembly Condition="Exists('../../assets/SerilogTracing.snk')">true</SignAssembly>
         <AssemblyOriginatorKeyFile>../../assets/SerilogTracing.snk</AssemblyOriginatorKeyFile>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
This should also enable symbol publishing to NuGet.org.