### PR TITLE
Sampling policies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>12</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <VersionPrefix>2.1.3</VersionPrefix>
+        <VersionPrefix>2.2.0</VersionPrefix>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- The condition is required to support BenchmarkDotNet -->

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ More sophisticated sampling strategies can be plugged in through `Sample.Using()
 > [!NOTE]
 > Once a sampling decision has been made for the root activity in a trace, SerilogTracing's sampling infrastructure will ensure all child activities inherit that sampling decision, regardless of the sampling policy in use. This means that when sampling decisions are communicated by a remote caller, care should be taken to either discard or trust that caller's decision. See the section [Adding instrumentation for ASP.NET Core requests](#adding-instrumentation-for-aspnet-core-requests) for information on how to do this with SerilogTracing's ASP.NET Core integration.
 
+Sampling does not affect the recording of log events: log events written during an un-sampled trace will still be recorded, and will carry trace and span ids even though the corresponding spans will be missing.
+
 ## How an `Activity` becomes a `LogEvent`
 
 ![SerilogTracing pipeline](https://raw.githubusercontent.com/serilog-tracing/serilog-tracing/dev/assets/pipeline-architecture.png)

--- a/README.md
+++ b/README.md
@@ -165,6 +165,27 @@ using var listener = new ActivityListenerConfiguration()
     .TraceToSharedLogger();
 ```
 
+### Incoming `traceparent` headers
+
+HTTP requests received by ASP.NET Core may contain a header with the trace id, span id, and sampling decision made for the active span in the calling application. How this header is used can be configured with `HttpRequestInActivityInstrumentationOptions.IncomingTraceParent`:
+
+```csharp
+using var listener = new ActivityListenerConfiguration()
+    .Instrument.AspNetCoreRequests(opts =>
+    {
+        opts.IncomingTraceParent = IncomingTraceParent.Trust;
+    })
+    .TraceToSharedLogger();
+```
+
+The supported options are:
+
+ * **`IncomingTraceParent.Accept`** (default) &mdash; the parent's trace and span ids will be used, but the sampling decision will be ignored; this reveals the presence of incoming tracing information while preventing callers from controlling whether data is recorded
+ * **`IncomingTraceParent.Ignore`** &mdash; no information about the parent span will be preserved; this is the appropriate option for most public or Internet-facing sites and services
+ * **`IncomingTraceParent.Trust`** &mdash; use the parent's trace and span ids, and respect the parent's sampling decision; this is the appropriate option for many internal services, since it allows system-wide sampling and consistent, detailed traces
+
+See the section [Sampling](#sampling) below for more information on how sampling works in SerilogTracing.
+
 ## Adding instrumentation for `HttpClient` requests
 
 `HttpClient` requests are instrumented by default. To configure the way `HttpClient` requests are recorded as spans, remove the default instrumentation and add `HttpClient` instrumentation explicitly:
@@ -237,6 +258,24 @@ Log.Logger = new LoggerConfiguration()
 
 For an example showing how to produce JSON with `ExpressionTemplate`, see the implementation of `ZipkinSink` in this repository,
 and [this article introducing _Serilog.Expressions_ JSON support](https://nblumhardt.com/2021/06/customize-serilog-json-output/).
+
+## Sampling
+
+Sampling is a method of reducing stored data volumes by selectively recording traces. This is similar to levelling, but instead of turning individual span types on and off, sampling causes either _all_ of the spans in a trace to be recorded, or _none_ of them.
+
+SerilogTracing implements two simple strategies via `ActivityListenerConfiguration`: `Sample.AllTraces()`, which records all traces (the default), and `Sample.OneTraceIn()`, which records a fixed proportion of possible traces:
+
+```csharp
+// Record only every 1000th trace
+using var listener = new ActivityListenerConfiguration()
+    .Sample.OneTraceIn(1000)
+    .TraceToSharedLogger();
+```
+
+More sophisticated sampling strategies can be plugged in through `Sample.Using()`, which provides access to the raw `System.Diagnostics.ActivityListener` sampling API.
+
+> [!NOTE]
+> Once a sampling decision has been made for the root activity in a trace, SerilogTracing's sampling infrastructure will ensure all child activities inherit that sampling decision, regardless of the sampling policy in use. This means that when sampling decisions are communicated by a remote caller, care should be taken to either discard or trust that caller's decision. See the section [Adding instrumentation for ASP.NET Core requests](#adding-instrumentation-for-aspnet-core-requests) for information on how to do this with SerilogTracing's ASP.NET Core integration.
 
 ## How an `Activity` becomes a `LogEvent`
 

--- a/example/Sampling/Program.cs
+++ b/example/Sampling/Program.cs
@@ -1,7 +1,5 @@
-﻿using System.Diagnostics;
-using Serilog;
+﻿using Serilog;
 using SerilogTracing;
-using SerilogTracing.Configuration;
 using SerilogTracing.Expressions;
 
 Log.Logger = new LoggerConfiguration()
@@ -9,7 +7,7 @@ Log.Logger = new LoggerConfiguration()
     .CreateLogger();
 
 using var _ = new ActivityListenerConfiguration()
-    .Sample.Using(IntervalSampler.Create(7))
+    .Sample.OneTraceIn(7)
     .TraceToSharedLogger();
 
 for (var i = 0; i < 10000; ++i)
@@ -17,42 +15,4 @@ for (var i = 0; i < 10000; ++i)
     using var outer = Log.Logger.StartActivity("Outer {i}", i);
     using var inner = Log.Logger.StartActivity("Inner {i}", i);
     await Task.Delay(100);
-}
-
-/// <summary>
-/// Record one trace in every <c>N</c>.
-/// </summary>
-static class IntervalSampler
-{
-    /// <summary>
-    /// Create a sampling delegate that records one trace in every <paramref name="interval"/> possible traces.
-    /// </summary>
-    /// <param name="interval">The sampling interval. Note that this is per root activity, not per individual activity.</param>
-    /// <returns>A sampling function that can be provided to <see cref="ActivityListenerSamplingConfiguration.Using"/>.</returns>
-    public static SampleActivity<ActivityContext> Create(ulong interval)
-    {
-        ArgumentOutOfRangeException.ThrowIfZero(interval);
-        var next = interval - 1;
-        
-        return (ref ActivityCreationOptions<ActivityContext> options) =>
-        {
-            if (options.Parent != default)
-            {
-                // The activity is a child of another; if the parent is recorded, the child is recorded. Otherwise,
-                // as long as a local activity is present, there's no need to generate an activity at all.
-                return (options.Parent.TraceFlags & ActivityTraceFlags.Recorded) == ActivityTraceFlags.Recorded ?
-                    ActivitySamplingResult.AllDataAndRecorded :
-                    options.Parent.IsRemote ?
-                        ActivitySamplingResult.PropagationData :
-                        ActivitySamplingResult.None;
-            }
-
-            // We're at the root; if the trace is not included in the sample, return `PropagationData` so that
-            // we apply the same decision to child activities via the path above.
-            var n = Interlocked.Increment(ref next) % interval;
-            return n == 0
-                ? ActivitySamplingResult.AllDataAndRecorded
-                : ActivitySamplingResult.PropagationData;
-        };
-    }
 }

--- a/src/SerilogTracing/Configuration/ActivityListenerSamplingConfiguration.cs
+++ b/src/SerilogTracing/Configuration/ActivityListenerSamplingConfiguration.cs
@@ -30,7 +30,7 @@ public class ActivityListenerSamplingConfiguration
     internal ActivityListenerSamplingConfiguration(ActivityListenerConfiguration activityListenerConfiguration)
     {
         _activityListenerConfiguration = activityListenerConfiguration;
-        _sample = ParentPrecedenceSampler.Create(AlwaysRecordedSampler.Create());
+        _sample = ParentPrecedentSampler.Create(AlwaysRecordedSampler.Create());
     }
 
     /// <summary>
@@ -62,7 +62,7 @@ public class ActivityListenerSamplingConfiguration
     /// <returns>The activity listener configuration, to enable method chaining.</returns>
     public ActivityListenerConfiguration AllTraces()
     {
-        _sample = ParentPrecedenceSampler.Create(AlwaysRecordedSampler.Create());
+        _sample = ParentPrecedentSampler.Create(AlwaysRecordedSampler.Create());
         return _activityListenerConfiguration;
     }
 
@@ -77,7 +77,7 @@ public class ActivityListenerSamplingConfiguration
     /// <returns>The activity listener configuration, to enable method chaining.</returns>
     public ActivityListenerConfiguration OneTraceIn(ulong interval)
     {
-        _sample = ParentPrecedenceSampler.Create(IntervalSampler.Create(interval));
+        _sample = ParentPrecedentSampler.Create(IntervalSampler.Create(interval));
         return _activityListenerConfiguration;
     }
 }

--- a/src/SerilogTracing/Configuration/ActivityListenerSamplingConfiguration.cs
+++ b/src/SerilogTracing/Configuration/ActivityListenerSamplingConfiguration.cs
@@ -67,7 +67,8 @@ public class ActivityListenerSamplingConfiguration
     }
 
     /// <summary>
-    /// Record one trace in every <paramref name="interval"/> possible traces.
+    /// Record one trace in every <paramref name="interval"/> possible traces. The sampling algorithm uses a simple local
+    /// counter, which is not preserved across application restarts.
     /// </summary>
     /// <param name="interval">The sampling interval. Note that this is per root activity, not per individual activity.</param>
     /// <remarks>This policy will respect any sampling decisions already made for parent activities. This will only

--- a/src/SerilogTracing/Interop/LoggerActivityListener.cs
+++ b/src/SerilogTracing/Interop/LoggerActivityListener.cs
@@ -53,22 +53,6 @@ sealed class LoggerActivityListener: IDisposable
             var samplingDelegate = configuration.Sample.SamplingDelegate;
             var activityEventRecording = configuration.ActivityEvents.Options;
 
-            samplingDelegate ??= (ref ActivityCreationOptions<ActivityContext> options) =>
-            {
-                if (options.Parent != default)
-                {
-                    // The activity is a child of another; if the parent is recorded, the child is recorded. Otherwise,
-                    // as long as a local activity is present, there's no need to generate an activity at all.
-                    return (options.Parent.TraceFlags & ActivityTraceFlags.Recorded) == ActivityTraceFlags.Recorded ?
-                        ActivitySamplingResult.AllDataAndRecorded :
-                        options.Parent.IsRemote ?
-                            ActivitySamplingResult.PropagationData :
-                            ActivitySamplingResult.None;
-                }
-
-                return ActivitySamplingResult.AllDataAndRecorded;
-            };
-
             if (ignoreLevelChanges)
             {
                 activityListener.ShouldListenTo = source => GetLogger(source.Name)

--- a/src/SerilogTracing/Samplers/AlwaysRecordedSampler.cs
+++ b/src/SerilogTracing/Samplers/AlwaysRecordedSampler.cs
@@ -1,0 +1,31 @@
+// Copyright © SerilogTracing Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics;
+
+namespace SerilogTracing.Samplers;
+
+/// <summary>
+/// Records all traces.
+/// </summary>
+static class AlwaysRecordedSampler
+{
+    /// <summary>
+    /// Create a sampling delegate that records all traces.
+    /// </summary>
+    public static SampleActivity<ActivityContext> Create()
+    {
+        return (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
+    }
+}

--- a/src/SerilogTracing/Samplers/IntervalSampler.cs
+++ b/src/SerilogTracing/Samplers/IntervalSampler.cs
@@ -32,14 +32,14 @@ static class IntervalSampler
         if (interval == 0) throw new ArgumentOutOfRangeException(nameof(interval));
         var next = (long)interval - 1;
         
-        return (ref ActivityCreationOptions<ActivityContext> _) =>
+        return (ref ActivityCreationOptions<ActivityContext> options) =>
         {
-            // Tf the trace is not included in the sample, return `PropagationData` so that
+            // If the trace is not included in the sample, return `PropagationData` so that
             // we apply the same decision to child activities via the path above.
             var n = Interlocked.Increment(ref next) % (long)interval;
-            return n == 0
-                ? ActivitySamplingResult.AllDataAndRecorded
-                : ActivitySamplingResult.PropagationData;
+            return n == 0 ?
+                ActivitySamplingResult.AllDataAndRecorded :
+                ActivitySamplingResult.PropagationData;
         };
     }
 }

--- a/src/SerilogTracing/Samplers/IntervalSampler.cs
+++ b/src/SerilogTracing/Samplers/IntervalSampler.cs
@@ -1,0 +1,45 @@
+// Copyright © SerilogTracing Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics;
+using SerilogTracing.Configuration;
+
+namespace SerilogTracing.Samplers;
+
+/// <summary>
+/// Record one trace in every <c>N</c>.
+/// </summary>
+static class IntervalSampler
+{
+    /// <summary>
+    /// Create a sampling delegate that records one trace in every <paramref name="interval"/> possible traces.
+    /// </summary>
+    /// <param name="interval">The sampling interval. Note that this is per root activity, not per individual activity.</param>
+    /// <returns>A sampling function that can be provided to <see cref="ActivityListenerSamplingConfiguration.Using"/>.</returns>
+    public static SampleActivity<ActivityContext> Create(ulong interval)
+    {
+        if (interval == 0) throw new ArgumentOutOfRangeException(nameof(interval));
+        var next = (long)interval - 1;
+        
+        return (ref ActivityCreationOptions<ActivityContext> _) =>
+        {
+            // Tf the trace is not included in the sample, return `PropagationData` so that
+            // we apply the same decision to child activities via the path above.
+            var n = Interlocked.Increment(ref next) % (long)interval;
+            return n == 0
+                ? ActivitySamplingResult.AllDataAndRecorded
+                : ActivitySamplingResult.PropagationData;
+        };
+    }
+}

--- a/src/SerilogTracing/Samplers/ParentPrecedenceSampler.cs
+++ b/src/SerilogTracing/Samplers/ParentPrecedenceSampler.cs
@@ -1,0 +1,50 @@
+// Copyright © SerilogTracing Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics;
+using SerilogTracing.Configuration;
+
+namespace SerilogTracing.Samplers;
+
+/// <summary>
+/// A sampling wrapper that gives precedence to the sampling decision made for the parent activity.
+/// </summary>
+static class ParentPrecedenceSampler
+{
+    /// <summary>
+    /// Create a sampling delegate that gives precedence to the sampling decision made for the parent activity, if present, but
+    /// otherwise delegates the sampling decision to <see paramref="sampleRootActivity"/>.
+    /// </summary>
+    /// <param name="sampleRootActivity">The sampler that will be used when no parent activity is present.</param>
+    /// <returns>A sampling function that can be provided to <see cref="ActivityListenerSamplingConfiguration.Using"/>.</returns>
+    public static SampleActivity<ActivityContext> Create(SampleActivity<ActivityContext> sampleRootActivity)
+    {
+        return (ref ActivityCreationOptions<ActivityContext> options) =>
+        {
+            if (options.Parent != default)
+            {
+                // The activity is a child of another; if the parent is recorded, the child is recorded. Otherwise,
+                // as long as a local activity is present, there's no need to generate an activity at all.
+                return (options.Parent.TraceFlags & ActivityTraceFlags.Recorded) == ActivityTraceFlags.Recorded ?
+                    ActivitySamplingResult.AllDataAndRecorded :
+                    options.Parent.IsRemote ?
+                        ActivitySamplingResult.PropagationData :
+                        ActivitySamplingResult.None;
+            }
+
+            // We're at the root; apply the nested sampler.
+            return sampleRootActivity(ref options);
+        };
+    }
+}

--- a/src/SerilogTracing/Samplers/ParentPrecedentSampler.cs
+++ b/src/SerilogTracing/Samplers/ParentPrecedentSampler.cs
@@ -20,7 +20,7 @@ namespace SerilogTracing.Samplers;
 /// <summary>
 /// A sampling wrapper that gives precedence to the sampling decision made for the parent activity.
 /// </summary>
-static class ParentPrecedenceSampler
+static class ParentPrecedentSampler
 {
     /// <summary>
     /// Create a sampling delegate that gives precedence to the sampling decision made for the parent activity, if present, but

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -91,6 +91,8 @@ namespace SerilogTracing.Configuration
     }
     public class ActivityListenerSamplingConfiguration
     {
+        public SerilogTracing.ActivityListenerConfiguration AllTraces() { }
+        public SerilogTracing.ActivityListenerConfiguration OneTraceIn(ulong interval) { }
         public SerilogTracing.ActivityListenerConfiguration Using(System.Diagnostics.SampleActivity<System.Diagnostics.ActivityContext> sample) { }
     }
 }

--- a/test/SerilogTracing.Tests/Samplers/AlwaysRecordedSamplerTests.cs
+++ b/test/SerilogTracing.Tests/Samplers/AlwaysRecordedSamplerTests.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics;
+using SerilogTracing.Samplers;
+using Xunit;
+
+namespace SerilogTracing.Tests.Samplers;
+
+public class AlwaysRecordedSamplerTests: SamplerTests
+{
+    [Theory]
+    [InlineData(false, false, false, ActivitySamplingResult.AllDataAndRecorded)]
+    [InlineData(true, false, false, ActivitySamplingResult.AllDataAndRecorded)]
+    [InlineData(true, true, false, ActivitySamplingResult.AllDataAndRecorded)]
+    [InlineData(true, false, true, ActivitySamplingResult.AllDataAndRecorded)]
+    [InlineData(true, true, true, ActivitySamplingResult.AllDataAndRecorded)]
+    public void SamplingDecisionIsAlwaysRecorded(bool hasParent, bool parentIsRemote, bool parentIsRecorded, ActivitySamplingResult expected)
+    {
+        var parentContext = hasParent
+            ? new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
+                parentIsRecorded ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None,
+                traceState: null,
+                isRemote: parentIsRemote)
+            : default;
+
+        var sampler = AlwaysRecordedSampler.Create();
+        
+        var decision = GetSamplingDecision(sampler, ActivityKind.Internal, parentContext);
+
+        Assert.Equal(expected, decision);
+    }
+}

--- a/test/SerilogTracing.Tests/Samplers/IntervalSamplerTests.cs
+++ b/test/SerilogTracing.Tests/Samplers/IntervalSamplerTests.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using SerilogTracing.Samplers;
+using Xunit;
+
+namespace SerilogTracing.Tests.Samplers;
+
+public class IntervalSamplerTests: SamplerTests
+{
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, true)]
+    public void OneTraceInNIsRecorded(bool hasParent, bool parentIsRemote, bool parentIsRecorded)
+    {
+        var parentContext = hasParent
+            ? new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
+                parentIsRecorded ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None,
+                traceState: null,
+                isRemote: parentIsRemote)
+            : default;
+
+        var sampler = IntervalSampler.Create(7);
+        var recordedCount = 0;
+        for (var i = 0; i < 77; ++i)
+        {
+            var result = GetSamplingDecision(sampler, ActivityKind.Internal, parentContext);
+            if (result == ActivitySamplingResult.AllDataAndRecorded)
+            {
+                recordedCount += 1;
+            }
+            else
+            {
+                Assert.Equal(ActivitySamplingResult.PropagationData, result);
+            }
+        }
+        
+        Assert.Equal(11, recordedCount);
+    }
+}

--- a/test/SerilogTracing.Tests/Samplers/ParentPrecedentSamplerTests.cs
+++ b/test/SerilogTracing.Tests/Samplers/ParentPrecedentSamplerTests.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics;
+using SerilogTracing.Samplers;
+using Xunit;
+
+namespace SerilogTracing.Tests.Samplers;
+
+public class ParentPrecedentSamplerTests: SamplerTests
+{
+    [Theory]
+    [InlineData(false, false, false, null)]
+    [InlineData(true, false, false, ActivitySamplingResult.None)]
+    [InlineData(true, true, false, ActivitySamplingResult.PropagationData)]
+    [InlineData(true, false, true, ActivitySamplingResult.AllDataAndRecorded)]
+    [InlineData(true, true, true, ActivitySamplingResult.AllDataAndRecorded)]
+    public void SamplingDecisionAlwaysFollowsParent(bool hasParent, bool parentIsRemote, bool parentIsRecorded, ActivitySamplingResult? expected)
+    {
+        var parentContext = hasParent
+            ? new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
+                parentIsRecorded ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None,
+                traceState: null,
+                isRemote: parentIsRemote)
+            : default;
+
+        var deferredToNested = false;
+        var sampler = ParentPrecedentSampler.Create((ref ActivityCreationOptions<ActivityContext> options) =>
+        {
+            deferredToNested = true;
+            return ActivitySamplingResult.None;
+        });
+        
+        var decision = GetSamplingDecision(sampler, ActivityKind.Internal, parentContext);
+
+        if (expected is { } fromParent)
+        {
+            Assert.Equal(fromParent, decision);
+            Assert.False(deferredToNested);
+        }
+        else
+        {
+            Assert.True(deferredToNested);
+        }
+    }
+}

--- a/test/SerilogTracing.Tests/Samplers/SamplerTests.cs
+++ b/test/SerilogTracing.Tests/Samplers/SamplerTests.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace SerilogTracing.Tests.Samplers;
+
+public abstract class SamplerTests
+{
+    protected static ActivitySamplingResult GetSamplingDecision(SampleActivity<ActivityContext> sampler, ActivityKind kind, ActivityContext parentContext)
+    {
+        using var source = new ActivitySource(Guid.NewGuid().ToString("n"));
+
+        using var listener = new ActivityListener();
+        
+        // ReSharper disable once AccessToDisposedClosure
+        listener.ShouldListenTo = s => s == source;
+        
+        ActivitySamplingResult? decision = null;
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
+        {
+            var actual = sampler(ref options);
+            decision = actual;
+            return actual;
+        };
+        
+        ActivitySource.AddActivityListener(listener);
+
+        source.CreateActivity(Guid.NewGuid().ToString("n"), kind, parentContext);
+        
+        Assert.NotNull(decision);
+        
+        return decision.Value;
+    }
+}


### PR DESCRIPTION
This PR adds two pre-baked sampling policies: `Sample.AllTraces()` (the existing default) and `Sample.OneTraceIn()`, a trivial interval-based sampler.

Though `Sample.OneTraceIn()` may be useful in some circumstances, the primary goal of adding it at this point is to properly document and exercise SerilogTracing's integration with `ActivityListener` sampling.

Internally, sampling policies are split into fine-grained strategies including a separate "decorator" that adds parent precedence to another (non-parent aware) sampling strategy that will be applied to root activities.

One aspect of the API proposed here that may not be immediately obvious is that the externally-configurable options `AllTraces()` and `OneTraceIn()` always wrap the selected strategy in the parent precedent decorator. This is because sampling without parent precedence is rarely, if ever, what the user will desire. There's an escape hatch, however, with `Sample.Using()` allowing configuration of strategies that ignore parent sampling decisions.

The additional README sections included in the PR add some information about how sampling interacts with the ASP.NET Core integration.