### PR TITLE
Expose the `InitialLevel.IgnoreChanges()` optimization

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>12</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <VersionPrefix>2.2.1</VersionPrefix>
+        <VersionPrefix>2.3.0</VersionPrefix>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- The condition is required to support BenchmarkDotNet -->

--- a/src/SerilogTracing/ActivityListenerConfiguration.cs
+++ b/src/SerilogTracing/ActivityListenerConfiguration.cs
@@ -93,7 +93,7 @@ public class ActivityListenerConfiguration
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
     public IDisposable TraceTo(ILogger logger)
     {
-        return LoggerActivityListener.Configure(this, () => logger, ignoreLevelChanges: false);
+        return LoggerActivityListener.Configure(this, () => logger);
     }
 
     /// <summary>
@@ -105,6 +105,6 @@ public class ActivityListenerConfiguration
     /// <returns>A handle that must be kept alive while tracing is required, and disposed afterwards.</returns>
     public IDisposable TraceToSharedLogger()
     {
-        return LoggerActivityListener.Configure(this, () => Log.Logger, ignoreLevelChanges: false);
+        return LoggerActivityListener.Configure(this, () => Log.Logger);
     }
 }

--- a/src/SerilogTracing/Configuration/ActivityListenerInitialLevelConfiguration.cs
+++ b/src/SerilogTracing/Configuration/ActivityListenerInitialLevelConfiguration.cs
@@ -28,8 +28,10 @@ public class ActivityListenerInitialLevelConfiguration
     readonly ActivityListenerConfiguration _activityListenerConfiguration;
     readonly Dictionary<string, LoggingLevelSwitch> _overrides = new();
     LogEventLevel _initialLevel = LogEventLevel.Information;
+    bool _ignoreLevelChanges;
 
     internal LevelOverrideMap GetOverrideMap() => new(_overrides, _initialLevel, null);
+    internal bool IgnoreLevelChanges => _ignoreLevelChanges;
 
     internal ActivityListenerInitialLevelConfiguration(ActivityListenerConfiguration activityListenerConfiguration)
     {
@@ -128,5 +130,20 @@ public class ActivityListenerInitialLevelConfiguration
     public ActivityListenerConfiguration Override(string activitySourceName, LogEventLevel level)
     {
         return Override(activitySourceName, new LoggingLevelSwitch(level));
+    }
+
+    /// <summary>
+    /// The first time an external activity source is encountered, check whether its initial level is enabled, and
+    /// cache this decision for the remainder of the listener's lifetime. This can be a significant performance and
+    /// memory usage optimization for apps that don't modify the target logger's minimum level at runtime.
+    /// </summary>
+    /// <remarks>If your application is using dynamic level control, either with <see cref="LoggingLevelSwitch"/>,
+    /// reloadable/bootstrap loggers, or by responding to configuration file changes at runtime, don't apply this
+    /// option.</remarks>
+    /// <returns>The activity listener configuration, to enable method chaining.</returns>
+    public ActivityListenerConfiguration IgnoreChanges()
+    {
+        _ignoreLevelChanges = true;
+        return _activityListenerConfiguration;
     }
 }

--- a/src/SerilogTracing/Interop/LoggerActivityListener.cs
+++ b/src/SerilogTracing/Interop/LoggerActivityListener.cs
@@ -33,8 +33,7 @@ sealed class LoggerActivityListener: IDisposable
     }
     
     internal static LoggerActivityListener Configure(
-        ActivityListenerConfiguration configuration, Func<ILogger> logger,
-        bool ignoreLevelChanges)
+        ActivityListenerConfiguration configuration, Func<ILogger> logger)
     {
         ILogger GetLogger(string name)
         {
@@ -53,7 +52,7 @@ sealed class LoggerActivityListener: IDisposable
             var samplingDelegate = configuration.Sample.SamplingDelegate;
             var activityEventRecording = configuration.ActivityEvents.Options;
 
-            if (ignoreLevelChanges)
+            if (configuration.InitialLevel.IgnoreLevelChanges)
             {
                 activityListener.ShouldListenTo = source => GetLogger(source.Name)
                     .IsEnabled(GetInitialLevel(levelMap, source.Name));

--- a/src/SerilogTracing/TracingConfiguration.cs
+++ b/src/SerilogTracing/TracingConfiguration.cs
@@ -14,6 +14,7 @@
 
 using System.Diagnostics;
 using Serilog;
+using Serilog.Events;
 using SerilogTracing.Configuration;
 // ReSharper disable MemberCanBePrivate.Global
 // ReSharper disable UnusedMember.Global
@@ -40,7 +41,9 @@ public class TracingConfiguration
     public ActivityListenerSamplingConfiguration Sample => _inner.Sample;
 
     /// <summary>
-    /// Configures the initial level assigned to externally created activities.
+    /// Configures the initial level assigned to externally-created activities. Setting the level of an external
+    /// activity source to a lower value, such as <see cref="LogEventLevel.Debug"/>, causes activities from that
+    /// source to be suppressed when the level is not enabled.
     /// </summary>
     public ActivityListenerInitialLevelConfiguration InitialLevel => _inner.InitialLevel;
 

--- a/test/SerilogTracing.Benchmarks/LoggerActivityTracingOnBenchmarks.cs
+++ b/test/SerilogTracing.Benchmarks/LoggerActivityTracingOnBenchmarks.cs
@@ -22,6 +22,7 @@ public class LoggerActivityTracingOnBenchmarks: IDisposable
     public LoggerActivityTracingOnBenchmarks()
     {
         _loggerActivityListener = new ActivityListenerConfiguration()
+            .InitialLevel.IgnoreChanges()
             .InitialLevel.Override(_ignoredSource.Name, LogEventLevel.Verbose)
             .Instrument.WithDefaultInstrumentation(false)
             .TraceTo(_log);

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -75,6 +75,7 @@ namespace SerilogTracing.Configuration
         public SerilogTracing.ActivityListenerConfiguration Debug() { }
         public SerilogTracing.ActivityListenerConfiguration Error() { }
         public SerilogTracing.ActivityListenerConfiguration Fatal() { }
+        public SerilogTracing.ActivityListenerConfiguration IgnoreChanges() { }
         public SerilogTracing.ActivityListenerConfiguration Information() { }
         public SerilogTracing.ActivityListenerConfiguration Is(Serilog.Events.LogEventLevel level) { }
         public SerilogTracing.ActivityListenerConfiguration Override(string activitySourceName, Serilog.Core.LoggingLevelSwitch levelSwitch) { }


### PR DESCRIPTION
#84 introduced an internal setting `ignoreLevelChanges` that optimizes the way the SerilogTracing activity listener handles external sources.

When the setting is enabled, external sources that are suppressed are permanently ignored, an no further checks are made when they attempt to start activities.

This is in contrast to the default behavior, which performs a check every time an activity is started, to properly respond to minimum level changes in the target logger.

This PR exposes the setting as `InitialLevel.IgnoreChanges()`:

```csharp
        _loggerActivityListener = new ActivityListenerConfiguration()
            .InitialLevel.IgnoreChanges()
            .InitialLevel.Override(_ignoredSource.Name, LogEventLevel.Verbose)
            .Instrument.WithDefaultInstrumentation(false)
            .TraceTo(_log);
```

Benchmark results are tricky to interpret, because this benchmark isn't particularly well-constructed, but they're a reasonable indication of the expected performance gains:

```
BenchmarkDotNet v0.13.12, macOS Sonoma 14.6.1 (23G93) [Darwin 23.6.0]
Apple M3 Pro, 1 CPU, 11 logical and 11 physical cores
.NET SDK 8.0.402
  [Host]     : .NET 8.0.8 (8.0.824.36612), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.8 (8.0.824.36612), Arm64 RyuJIT AdvSIMD
```

**Before:**

| Method                 | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|----------------------- |---------:|--------:|--------:|------:|--------:|-------:|-------:|----------:|------------:|
| ActivitySourceBaseline | 202.9 ns | 0.90 ns | 0.80 ns |  1.00 |    0.00 | 0.0823 |      - |     688 B |        1.00 |
| ActivityListenerOnly   | 347.6 ns | 1.63 ns | 1.45 ns |  1.71 |    0.01 | 0.1469 |      - |    1232 B |        1.79 |
| StartThenDispose       | 359.9 ns | 1.56 ns | 1.46 ns |  1.77 |    0.01 | 0.1392 | 0.0005 |    1168 B |        1.70 |
| StartThenComplete      | 727.8 ns | 1.24 ns | 1.16 ns |  3.59 |    0.02 | 0.2394 | 0.0010 |    2008 B |        2.92 |

**After:**

| Method                 | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
|----------------------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
| ActivitySourceBaseline | 141.4 ns | 0.34 ns | 0.32 ns |  1.00 | 0.0496 |     416 B |        1.00 |
| ActivityListenerOnly   | 319.7 ns | 0.77 ns | 0.68 ns |  2.26 | 0.1307 |    1096 B |        2.63 |
| StartThenDispose       | 306.1 ns | 0.54 ns | 0.51 ns |  2.17 | 0.1230 |    1032 B |        2.48 |
| StartThenComplete      | 659.5 ns | 1.12 ns | 0.94 ns |  4.67 | 0.2232 |    1872 B |        4.50 |

The two `SerilogTracing` cases - `StartThenDispose()` and `StartThenComplete()` - pick up a better than 10% improvement in execution time, a similar allocation benefit, and both stop triggering Gen1 collections.

The `Activity*` cases point to how external activity sources will be made more efficient with this change - a better than 25% improvement in run-time and allocations. This is the case that's motivating my PR - I'm integrating SerilogTracing into a codebase with extremely high-frequency but suppressed activities present.