### PR TITLE
Add `HttpRequestInActivityInstrumentationOptions.PostSamplingFilter`

### DIFF
--- a/example/Example.WeatherService/Program.cs
+++ b/example/Example.WeatherService/Program.cs
@@ -18,7 +18,11 @@ Log.Logger = new LoggerConfiguration()
     .CreateLogger();
 
 using var _ = new ActivityListenerConfiguration()
-    .Instrument.AspNetCoreRequests(opts => opts.IncomingTraceParent = IncomingTraceParent.Trust)
+    .Instrument.AspNetCoreRequests(opts =>
+    {
+        opts.IncomingTraceParent = IncomingTraceParent.Trust;
+        opts.PostSamplingFilter = httpContext => !httpContext.Request.Path.StartsWithSegments("/health");
+    })
     .TraceToSharedLogger();
 
 Log.Information("Weather service starting up");
@@ -41,6 +45,8 @@ try
 
         return forecast;
     });
+
+    app.MapGet("/health", () => "Ok!");
 
     app.Run();
 

--- a/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentationOptions.cs
+++ b/src/SerilogTracing.Instrumentation.AspNetCore/Instrumentation/AspNetCore/HttpRequestInActivityInstrumentationOptions.cs
@@ -79,4 +79,11 @@ public sealed class HttpRequestInActivityInstrumentationOptions
     /// <c langword="true"/> if the status code is 500 or greater, and the request was not aborted.
     /// </summary>
     public Func<HttpResponse, bool> IsErrorResponse { get; set; } = DefaultIsErrorResponse;
+    
+    /// <summary>
+    /// An additional filter that will be applied after sampling. If the filter returns <c langword="false"/> then
+    /// the sampling decision and parent sampling flags (if applicable) will be ignored, and the activity will
+    /// be suppressed. Use this to disable tracing entirely for specific routes or callers.
+    /// </summary>
+    public Func<HttpContext, bool>? PostSamplingFilter { get; set; }
 }

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.Instrumentation.AspNetCore.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.Instrumentation.AspNetCore.approved.txt
@@ -22,5 +22,6 @@ namespace SerilogTracing.Instrumentation.AspNetCore
         public SerilogTracing.IncomingTraceParent IncomingTraceParent { get; set; }
         public System.Func<Microsoft.AspNetCore.Http.HttpResponse, bool> IsErrorResponse { get; set; }
         public string MessageTemplate { get; set; }
+        public System.Func<Microsoft.AspNetCore.Http.HttpContext, bool>? PostSamplingFilter { get; set; }
     }
 }


### PR DESCRIPTION
This API provides a strong method of disabling tracing for particular web requests, e.g. for a particular request path/endpoint, method, caller, etc.

The weather service example has been updated to show this in action:

```csharp
using var _ = new ActivityListenerConfiguration()
    .Instrument.AspNetCoreRequests(opts =>
    {
        opts.IncomingTraceParent = IncomingTraceParent.Trust;
        opts.PostSamplingFilter = httpContext => !httpContext.Request.Path.StartsWithSegments("/health");
    })
    .TraceToSharedLogger();
```

The filter runs after sampling, hence the name.

A pre-sampling filter might also be possible, but this would require some additional mechanism to "remember" suppression, so that child activities would also be suppressed. Post-sampling is fine for my current purposes but this could be interesting to revisit in the future.