### PR TITLE
Support plugging in instrumentation based on ActivitySources

### DIFF
--- a/src/SerilogTracing/Core/Constants.cs
+++ b/src/SerilogTracing/Core/Constants.cs
@@ -64,6 +64,7 @@ public static class Constants
     internal const string ExceptionStackTraceTagName = "exception.stacktrace";
     internal const string ExceptionTypeTagName = "exception.type";
 
+    // Internal but publicly visible via `DiagnosticListener`
     internal const string SerilogTracingDiagnosticSourceName = "SerilogTracing.ActivitySource";
     internal const string SerilogTracingActivityStartedEventName = "ActivityStarted";
     internal const string SerilogTracingActivityStoppedEventName = "ActivityStopped";

--- a/src/SerilogTracing/Core/Constants.cs
+++ b/src/SerilogTracing/Core/Constants.cs
@@ -63,4 +63,8 @@ public static class Constants
     internal const string ExceptionMessageTagName = "exception.message";
     internal const string ExceptionStackTraceTagName = "exception.stacktrace";
     internal const string ExceptionTypeTagName = "exception.type";
+
+    internal const string SerilogTracingDiagnosticSourceName = "SerilogTracing.ActivitySource";
+    internal const string SerilogTracingActivityStartedEventName = "ActivityStarted";
+    internal const string SerilogTracingActivityStoppedEventName = "ActivityStopped";
 }

--- a/src/SerilogTracing/Instrumentation/ActivitySourceInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/ActivitySourceInstrumentor.cs
@@ -27,7 +27,7 @@ public abstract class ActivitySourceInstrumentor : IActivityInstrumentor
     /// </summary>
     /// <param name="activitySourceName">The <see cref="ActivitySource.Name"/> of the candidate <see cref="ActivitySource"/>.</param>
     /// <returns>Whether the instrumentor should instrument activities from the given source.</returns>
-    protected abstract bool ShouldSubscribeTo(string activitySourceName);
+    public abstract bool ShouldSubscribeTo(string activitySourceName);
 
     /// <summary>
     /// Enrich an activity.
@@ -35,7 +35,7 @@ public abstract class ActivitySourceInstrumentor : IActivityInstrumentor
     /// <remarks>This method will only be called by SerilogTracing for activities that are expected to be enriched with data.
     /// This is, activities where <see cref="Activity.IsAllDataRequested"/> is true.</remarks>
     /// <param name="activity">The activity to enrich with instrumentation.</param>
-    protected abstract void InstrumentActivity(Activity activity);
+    public abstract void InstrumentActivity(Activity activity);
     
     /// <inheritdoc />
     bool IActivityInstrumentor.ShouldSubscribeTo(string diagnosticListenerName)

--- a/src/SerilogTracing/Instrumentation/ActivitySourceInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/ActivitySourceInstrumentor.cs
@@ -40,7 +40,7 @@ public abstract class ActivitySourceInstrumentor : IActivityInstrumentor
     /// <inheritdoc />
     bool IActivityInstrumentor.ShouldSubscribeTo(string diagnosticListenerName)
     {
-        return diagnosticListenerName == Constants.SerilogTracingActivitySourceName;
+        return diagnosticListenerName == Constants.SerilogTracingDiagnosticSourceName;
     }
     
     /// <inheritdoc />

--- a/src/SerilogTracing/Instrumentation/ActivitySourceInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/ActivitySourceInstrumentor.cs
@@ -35,22 +35,16 @@ public abstract class ActivitySourceInstrumentor : IActivityInstrumentor
     /// <remarks>This method will only be called by SerilogTracing for activities that are expected to be enriched with data.
     /// This is, activities where <see cref="Activity.IsAllDataRequested"/> is true.</remarks>
     /// <param name="activity">The activity to enrich with instrumentation.</param>
-    public virtual void InstrumentOnActivityStarted(Activity activity)
-    {
-        
-    }
-    
+    public virtual void InstrumentOnActivityStarted(Activity activity) { }
+
     /// <summary>
     /// Enrich an activity when it's stopped.
     /// </summary>
     /// <remarks>This method will only be called by SerilogTracing for activities that are expected to be enriched with data.
     /// This is, activities where <see cref="Activity.IsAllDataRequested"/> is true.</remarks>
     /// <param name="activity">The activity to enrich with instrumentation.</param>
-    public virtual void InstrumentOnActivityStopped(Activity activity)
-    {
-        
-    }
-    
+    public virtual void InstrumentOnActivityStopped(Activity activity) { }
+
     /// <inheritdoc />
     bool IActivityInstrumentor.ShouldSubscribeTo(string diagnosticListenerName)
     {

--- a/src/SerilogTracing/Instrumentation/ActivitySourceInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/ActivitySourceInstrumentor.cs
@@ -30,12 +30,26 @@ public abstract class ActivitySourceInstrumentor : IActivityInstrumentor
     public abstract bool ShouldSubscribeTo(string activitySourceName);
 
     /// <summary>
-    /// Enrich an activity.
+    /// Enrich an activity when it's started.
     /// </summary>
     /// <remarks>This method will only be called by SerilogTracing for activities that are expected to be enriched with data.
     /// This is, activities where <see cref="Activity.IsAllDataRequested"/> is true.</remarks>
     /// <param name="activity">The activity to enrich with instrumentation.</param>
-    public abstract void InstrumentActivity(Activity activity);
+    public virtual void InstrumentOnActivityStarted(Activity activity)
+    {
+        
+    }
+    
+    /// <summary>
+    /// Enrich an activity when it's stopped.
+    /// </summary>
+    /// <remarks>This method will only be called by SerilogTracing for activities that are expected to be enriched with data.
+    /// This is, activities where <see cref="Activity.IsAllDataRequested"/> is true.</remarks>
+    /// <param name="activity">The activity to enrich with instrumentation.</param>
+    public virtual void InstrumentOnActivityStopped(Activity activity)
+    {
+        
+    }
     
     /// <inheritdoc />
     bool IActivityInstrumentor.ShouldSubscribeTo(string diagnosticListenerName)
@@ -52,7 +66,14 @@ public abstract class ActivitySourceInstrumentor : IActivityInstrumentor
                 if (!ShouldSubscribeTo(activity.Source.Name))
                     return;
                 
-                InstrumentActivity(activity);
+                InstrumentOnActivityStarted(activity);
+                return;
+            
+            case Constants.SerilogTracingActivityStoppedEventName:
+                if (!ShouldSubscribeTo(activity.Source.Name))
+                    return;
+                
+                InstrumentOnActivityStopped(activity);
                 return;
         }
     }

--- a/src/SerilogTracing/Instrumentation/ActivitySourceInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/ActivitySourceInstrumentor.cs
@@ -1,0 +1,59 @@
+// Copyright © SerilogTracing Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics;
+using SerilogTracing.Core;
+
+namespace SerilogTracing.Instrumentation;
+
+/// <summary>
+/// Instrument <see cref="Activity">activities</see> from an <see cref="System.Diagnostics.ActivitySource" />.
+/// </summary>
+public abstract class ActivitySourceInstrumentor : IActivityInstrumentor
+{
+    /// <summary>
+    /// Whether the instrumentor should subscribe to events from the given <see cref="ActivitySource"/>.
+    /// </summary>
+    /// <param name="activitySourceName">The <see cref="ActivitySource.Name"/> of the candidate <see cref="ActivitySource"/>.</param>
+    /// <returns>Whether the instrumentor should instrument activities from the given source.</returns>
+    protected abstract bool ShouldSubscribeTo(string activitySourceName);
+
+    /// <summary>
+    /// Enrich an activity.
+    /// </summary>
+    /// <remarks>This method will only be called by SerilogTracing for activities that are expected to be enriched with data.
+    /// This is, activities where <see cref="Activity.IsAllDataRequested"/> is true.</remarks>
+    /// <param name="activity">The activity to enrich with instrumentation.</param>
+    protected abstract void InstrumentActivity(Activity activity);
+    
+    /// <inheritdoc />
+    bool IActivityInstrumentor.ShouldSubscribeTo(string diagnosticListenerName)
+    {
+        return diagnosticListenerName == Constants.SerilogTracingActivitySourceName;
+    }
+    
+    /// <inheritdoc />
+    void IActivityInstrumentor.InstrumentActivity(Activity activity, string eventName, object eventArgs)
+    {
+        switch (eventName)
+        {
+            case Constants.SerilogTracingActivityStartedEventName:
+                if (!ShouldSubscribeTo(activity.Source.Name))
+                    return;
+                
+                InstrumentActivity(activity);
+                return;
+        }
+    }
+}

--- a/src/SerilogTracing/Instrumentation/IActivityInstrumentor.cs
+++ b/src/SerilogTracing/Instrumentation/IActivityInstrumentor.cs
@@ -17,8 +17,12 @@ using System.Diagnostics;
 namespace SerilogTracing.Instrumentation;
 
 /// <summary>
-/// Instrument <see cref="Activity">activities</see>.
+/// Instrument <see cref="Activity">activities</see> from a <see cref="DiagnosticSource" />.
 /// </summary>
+/// <remarks>
+/// Implementors are plugged in via <see cref="Configuration.ActivityListenerInstrumentationConfiguration.With">instrumentation configuration</see> to the SerilogTracing pipeline.
+/// To instrument activities from sources that use an <see cref="ActivitySource" /> instead of a diagnostic source, see <see cref="ActivitySourceInstrumentor" />.
+/// </remarks>
 public interface IActivityInstrumentor
 {
     /// <summary>
@@ -29,7 +33,7 @@ public interface IActivityInstrumentor
     bool ShouldSubscribeTo(string diagnosticListenerName);
 
     /// <summary>
-    /// Enrich the an activity with context from a diagnostic event.
+    /// Enrich an activity with context from a diagnostic event.
     /// </summary>
     /// <remarks>This method will only be called by SerilogTracing for activities that are expected to be enriched with data.
     /// This is, activities where <see cref="Activity.IsAllDataRequested"/> is true.</remarks>

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -122,7 +122,8 @@ namespace SerilogTracing.Instrumentation
     public abstract class ActivitySourceInstrumentor : SerilogTracing.Instrumentation.IActivityInstrumentor
     {
         protected ActivitySourceInstrumentor() { }
-        public abstract void InstrumentActivity(System.Diagnostics.Activity activity);
+        public virtual void InstrumentOnActivityStarted(System.Diagnostics.Activity activity) { }
+        public virtual void InstrumentOnActivityStopped(System.Diagnostics.Activity activity) { }
         public abstract bool ShouldSubscribeTo(string activitySourceName);
     }
     public interface IActivityInstrumentor

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -119,6 +119,12 @@ namespace SerilogTracing.Instrumentation
         public static void SetMessageTemplateOverride(System.Diagnostics.Activity activity, Serilog.Events.MessageTemplate messageTemplate) { }
         public static bool TrySetException(System.Diagnostics.Activity activity, System.Exception exception) { }
     }
+    public abstract class ActivitySourceInstrumentor : SerilogTracing.Instrumentation.IActivityInstrumentor
+    {
+        protected ActivitySourceInstrumentor() { }
+        public abstract void InstrumentActivity(System.Diagnostics.Activity activity);
+        public abstract bool ShouldSubscribeTo(string activitySourceName);
+    }
     public interface IActivityInstrumentor
     {
         void InstrumentActivity(System.Diagnostics.Activity activity, string eventName, object eventArgs);

--- a/test/SerilogTracing.Tests/Instrumentation/DiagnosticEventObserverTests.cs
+++ b/test/SerilogTracing.Tests/Instrumentation/DiagnosticEventObserverTests.cs
@@ -36,4 +36,30 @@ public class DiagnosticEventObserverTests
         Assert.Equal("event", instrumentor.EventName);
         Assert.Equal(true, instrumentor.EventArgs);
     }
+
+    [Fact]
+    public void ActivitySourceInstrumentorDoesNotSeeSuppressedActivities()
+    {
+        using var activity = Some.Activity();
+        activity.IsAllDataRequested = false;
+
+        var instrumentor = new CollectingActivitySourceInstrumentor();
+
+        new DiagnosticEventObserver(instrumentor).OnNext(activity, "ActivityStarted", activity);
+
+        Assert.Null(instrumentor.Activity);
+    }
+
+    [Fact]
+    public void ActivitySourceInstrumentorSeesUnsuppressedActivities()
+    {
+        using var activity = Some.Activity();
+        activity.IsAllDataRequested = true;
+
+        var instrumentor = new CollectingActivitySourceInstrumentor();
+
+        new DiagnosticEventObserver(instrumentor).OnNext(activity, "ActivityStarted", activity);
+
+        Assert.Equal(activity, instrumentor.Activity);
+    }
 }

--- a/test/SerilogTracing.Tests/Instrumentation/DiagnosticEventObserverTests.cs
+++ b/test/SerilogTracing.Tests/Instrumentation/DiagnosticEventObserverTests.cs
@@ -47,7 +47,8 @@ public class DiagnosticEventObserverTests
 
         new DiagnosticEventObserver(instrumentor).OnNext(activity, "ActivityStarted", activity);
 
-        Assert.Null(instrumentor.Activity);
+        Assert.Null(instrumentor.StartedActivity);
+        Assert.Null(instrumentor.StoppedActivity);
     }
 
     [Fact]
@@ -60,6 +61,11 @@ public class DiagnosticEventObserverTests
 
         new DiagnosticEventObserver(instrumentor).OnNext(activity, "ActivityStarted", activity);
 
-        Assert.Equal(activity, instrumentor.Activity);
+        Assert.Equal(activity, instrumentor.StartedActivity);
+        Assert.Null(instrumentor.StoppedActivity);
+        
+        new DiagnosticEventObserver(instrumentor).OnNext(activity, "ActivityStopped", activity);
+        
+        Assert.Equal(activity, instrumentor.StoppedActivity);
     }
 }

--- a/test/SerilogTracing.Tests/Support/CollectingActivitySourceInstrumentor.cs
+++ b/test/SerilogTracing.Tests/Support/CollectingActivitySourceInstrumentor.cs
@@ -5,15 +5,21 @@ namespace SerilogTracing.Tests.Support;
 
 class CollectingActivitySourceInstrumentor : ActivitySourceInstrumentor
 {
-    public Activity? Activity { get; set; }
+    public Activity? StartedActivity { get; set; }
+    public Activity? StoppedActivity { get; set; }
 
     public override bool ShouldSubscribeTo(string activitySourceName)
     {
         return true;
     }
 
-    public override void InstrumentActivity(Activity activity)
+    public override void InstrumentOnActivityStarted(Activity activity)
     {
-        Activity = activity;
+        StartedActivity = activity;
+    }
+    
+    public override void InstrumentOnActivityStopped(Activity activity)
+    {
+        StoppedActivity = activity;
     }
 }

--- a/test/SerilogTracing.Tests/Support/CollectingActivitySourceInstrumentor.cs
+++ b/test/SerilogTracing.Tests/Support/CollectingActivitySourceInstrumentor.cs
@@ -7,12 +7,12 @@ class CollectingActivitySourceInstrumentor : ActivitySourceInstrumentor
 {
     public Activity? Activity { get; set; }
 
-    protected override bool ShouldSubscribeTo(string activitySourceName)
+    public override bool ShouldSubscribeTo(string activitySourceName)
     {
         return true;
     }
 
-    protected override void InstrumentActivity(Activity activity)
+    public override void InstrumentActivity(Activity activity)
     {
         Activity = activity;
     }

--- a/test/SerilogTracing.Tests/Support/CollectingActivitySourceInstrumentor.cs
+++ b/test/SerilogTracing.Tests/Support/CollectingActivitySourceInstrumentor.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+using SerilogTracing.Instrumentation;
+
+namespace SerilogTracing.Tests.Support;
+
+class CollectingActivitySourceInstrumentor : ActivitySourceInstrumentor
+{
+    public Activity? Activity { get; set; }
+
+    protected override bool ShouldSubscribeTo(string activitySourceName)
+    {
+        return true;
+    }
+
+    protected override void InstrumentActivity(Activity activity)
+    {
+        Activity = activity;
+    }
+}


### PR DESCRIPTION
Closes #138 

This PR introduces a bridge between `DiagnosticSource`s and `ActivitySource`s so that libraries only using `ActivitySource`s for their instrumentation can still be enriched through SerilogTracing's `Instrument.With` infrastructure.

You can instrument an activity-source by inheriting from `ActivitySourceInstrumentor`:

```csharp
using SerilogTracing.Instrumentation;

using var _ = new ActivityListenerConfiguration()
    .Instrument.With<RabbitMQActivitySourceInstrumentor>()
    .TraceToSharedLogger();

class RabbitMQActivitySourceInstrumentor : ActivitySourceInstrumentor
{
    public override bool ShouldSubscribeTo(string activitySourceName)
    {
        return activitySourceName.StartsWith("RabbitMQ");
    }

    public override void InstrumentActivity(Activity activity)
    {
        ActivityInstrumentation.SetMessageTemplateOverride(..);
    }
}
```