### PR TITLE
Move LogEventTracingProperties into Interop namespace

### DIFF
--- a/src/SerilogTracing/Enrichers/LogEventTracingProperties.cs
+++ b/src/SerilogTracing/Enrichers/LogEventTracingProperties.cs
@@ -16,7 +16,7 @@ using System.Diagnostics.CodeAnalysis;
 using Serilog.Events;
 using SerilogTracing.Core;
 
-namespace SerilogTracing.Instrumentation;
+namespace SerilogTracing.Enrichers;
 
 static class LogEventTracingProperties
 {

--- a/src/SerilogTracing/Enrichers/SpanTimingEnricher.cs
+++ b/src/SerilogTracing/Enrichers/SpanTimingEnricher.cs
@@ -14,7 +14,6 @@
 
 using Serilog.Core;
 using Serilog.Events;
-using SerilogTracing.Instrumentation;
 
 namespace SerilogTracing.Enrichers;
 

--- a/src/SerilogTracing/Enrichers/SpanTimingMillisecondsEnricher.cs
+++ b/src/SerilogTracing/Enrichers/SpanTimingMillisecondsEnricher.cs
@@ -14,7 +14,6 @@
 
 using Serilog.Core;
 using Serilog.Events;
-using SerilogTracing.Instrumentation;
 
 namespace SerilogTracing.Enrichers;
 


### PR DESCRIPTION
This is just a nitpick refactoring of an internal type that I think is better suited to the `Interop` namespace, which deals with mapping activities to log events, than the `Instrumentation` namespace, which is largely about observing and enriching activities.