### PR TITLE
Support passing a parent context and activity kind through Logger.StartActivity

### DIFF
--- a/src/SerilogTracing/Interop/ActivityConvert.cs
+++ b/src/SerilogTracing/Interop/ActivityConvert.cs
@@ -71,12 +71,15 @@ static class ActivityConvert
             throw new InvalidOperationException("`LoggerActivity.Activity` is only `null` when activity is suppressed, so should never result in mapping to a `LogEvent`.");
         
         var activity = loggerActivity.Activity;
+        
         var start = activity.StartTimeUtc;
         var traceId = activity.TraceId;
         var spanId = activity.SpanId;
         var parentSpanId = activity.ParentSpanId;
-        var kind = activity.Kind;
+        
+        var kind = loggerActivity.Kind;
         var template = loggerActivity.MessageTemplate;
+        
         if (exception == null)
         {
             ActivityInstrumentation.TryGetException(activity, out exception);

--- a/src/SerilogTracing/Interop/LoggerActivitySource.cs
+++ b/src/SerilogTracing/Interop/LoggerActivitySource.cs
@@ -21,11 +21,8 @@ static class LoggerActivitySource
 {
     static ActivitySource Instance { get; } = new(Constants.SerilogTracingActivitySourceName, null);
 
-    public static Activity? TryStartActivity(string name, ActivityKind kind, ActivityContext parentContext)
+    public static Activity? TryStartActivity(string name, ActivityContext parentContext, ActivityKind kind)
     {
-        // `ActivityKind` might be passed through here in the future. The `Activity` constructor does
-        // not accept this.
-
         if (Instance.HasListeners())
         {
             // Tracing is enabled; if this returns `null`, sampling is suppressing the activity and so therefore
@@ -40,6 +37,7 @@ static class LoggerActivitySource
         // Tracing is not enabled. Levels are everything, and the level check has already been performed by the
         // caller, so we're in business!
 
+        // `kind` needs to be set on the `LoggerActivity` directly
         var manualActivity = new Activity(name);
 
         if (parentContext != default)

--- a/src/SerilogTracing/Interop/LoggerActivitySource.cs
+++ b/src/SerilogTracing/Interop/LoggerActivitySource.cs
@@ -21,7 +21,7 @@ static class LoggerActivitySource
 {
     static ActivitySource Instance { get; } = new(Constants.SerilogTracingActivitySourceName, null);
 
-    public static Activity? TryStartActivity(string name, ActivityContext parentContext, ActivityKind kind)
+    public static Activity? TryStartActivity(string name, ActivityKind kind, ActivityContext parentContext)
     {
         if (Instance.HasListeners())
         {

--- a/src/SerilogTracing/Interop/LoggerActivitySource.cs
+++ b/src/SerilogTracing/Interop/LoggerActivitySource.cs
@@ -21,7 +21,7 @@ static class LoggerActivitySource
 {
     static ActivitySource Instance { get; } = new(Constants.SerilogTracingActivitySourceName, null);
 
-    public static Activity? TryStartActivity(string name)
+    public static Activity? TryStartActivity(string name, ActivityKind kind, ActivityContext parentContext)
     {
         // `ActivityKind` might be passed through here in the future. The `Activity` constructor does
         // not accept this.
@@ -30,7 +30,7 @@ static class LoggerActivitySource
         {
             // Tracing is enabled; if this returns `null`, sampling is suppressing the activity and so therefore
             // should the logging layer.
-            var listenerActivity = Instance.CreateActivity(name, ActivityKind.Internal);
+            var listenerActivity = Instance.CreateActivity(name, kind, parentContext);
 
             listenerActivity?.Start();
 
@@ -41,7 +41,12 @@ static class LoggerActivitySource
         // caller, so we're in business!
 
         var manualActivity = new Activity(name);
-        if (Activity.Current is { } parent)
+
+        if (parentContext != default)
+        {
+            manualActivity.SetParentId(parentContext.TraceId, parentContext.SpanId, parentContext.TraceFlags);
+        }
+        else if (Activity.Current is { } parent)
         {
             manualActivity.SetParentId(parent.TraceId, parent.SpanId, parent.ActivityTraceFlags);
         }

--- a/src/SerilogTracing/LoggerActivity.cs
+++ b/src/SerilogTracing/LoggerActivity.cs
@@ -34,18 +34,20 @@ public sealed class LoggerActivity : IDisposable
     /// A <see cref="LoggerActivity"/> that represents a suppressed activity. The <see cref="Activity"/> property of
     /// this instance, and only this instance, will be <c langword="null"/>.
     /// </summary>
-    public static LoggerActivity None { get; } = new(new LoggerConfiguration().CreateLogger(), LevelAlias.Minimum, null, new(Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>());
+    public static LoggerActivity None { get; } = new(new LoggerConfiguration().CreateLogger(), LevelAlias.Minimum, null, default, new(Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>());
 
     internal LoggerActivity(
         ILogger logger,
         LogEventLevel defaultCompletionLevel,
         Activity? activity,
+        ActivityKind kind,
         MessageTemplate messageTemplate,
         IEnumerable<LogEventProperty> captures)
     {
         Logger = logger;
         DefaultCompletionLevel = defaultCompletionLevel;
         Activity = activity;
+        Kind = kind;
         MessageTemplate = messageTemplate;
         Properties = [];
 
@@ -63,6 +65,8 @@ public sealed class LoggerActivity : IDisposable
     ILogger Logger { get; }
     LogEventLevel DefaultCompletionLevel { get; }
     bool IsComplete { get; set; }
+    
+    internal ActivityKind Kind { get; }
 
     internal MessageTemplate MessageTemplate { get; }
     

--- a/src/SerilogTracing/LoggerTracingExtensions.cs
+++ b/src/SerilogTracing/LoggerTracingExtensions.cs
@@ -34,7 +34,7 @@ public static class LoggerTracingExtensions
     static readonly MessageTemplate FallbackTemplate = new MessageTemplateParser().Parse($"{{{FallbackTemplateOriginalTemplateName}}}");
 
     // This method checks preconditions for starting an activity, before a params array or `LoggerActivity` might need to be allocated.
-    static bool TryStartActivity(ILogger logger, ActivityContext parentContext, ActivityKind kind, LogEventLevel level, string messageTemplate, [NotNullWhen(true)] out Activity? activity)
+    static bool TryStartActivity(ILogger logger, ActivityKind kind, ActivityContext parentContext, LogEventLevel level, string messageTemplate, [NotNullWhen(true)] out Activity? activity)
     {
         if (logger == null! || messageTemplate == null!)
         {
@@ -48,7 +48,7 @@ public static class LoggerTracingExtensions
             return false;
         }
 
-        activity = LoggerActivitySource.TryStartActivity(messageTemplate, parentContext, kind);
+        activity = LoggerActivitySource.TryStartActivity(messageTemplate, kind, parentContext);
         return activity != null;
     }
 
@@ -82,9 +82,9 @@ public static class LoggerTracingExtensions
     /// These properties will also be attached to the resulting span.</param>
     /// <returns>A <see cref="LoggerActivity"/>.</returns>
     [MessageTemplateFormatMethod(nameof(messageTemplate))]
-    public static LoggerActivity StartActivity(this ILogger logger, ActivityContext parentContext, ActivityKind kind, LogEventLevel level, string messageTemplate, params object?[]? propertyValues)
+    public static LoggerActivity StartActivity(this ILogger logger, ActivityKind kind, ActivityContext parentContext, LogEventLevel level, string messageTemplate, params object?[]? propertyValues)
     {
-        return !TryStartActivity(logger, parentContext, kind, level, messageTemplate, out var activity) ?
+        return !TryStartActivity(logger, kind, parentContext, level, messageTemplate, out var activity) ?
             LoggerActivity.None :
             BindLoggerActivity(logger, level, messageTemplate, propertyValues, activity, kind);
     }
@@ -102,8 +102,8 @@ public static class LoggerTracingExtensions
     /// These properties will also be attached to the resulting span.</param>
     /// <returns>A <see cref="LoggerActivity"/>.</returns>
     [MessageTemplateFormatMethod(nameof(messageTemplate))]
-    public static LoggerActivity StartActivity(this ILogger logger, ActivityContext parentContext, ActivityKind kind, string messageTemplate, params object?[]? propertyValues)
-        => StartActivity(logger, parentContext, kind, LogEventLevel.Information, messageTemplate, propertyValues);
+    public static LoggerActivity StartActivity(this ILogger logger, ActivityKind kind, ActivityContext parentContext, string messageTemplate, params object?[]? propertyValues)
+        => StartActivity(logger, kind, parentContext, LogEventLevel.Information, messageTemplate, propertyValues);
 
     /// <summary>
     /// Start an activity.
@@ -119,9 +119,9 @@ public static class LoggerTracingExtensions
     /// <param name="messageTemplate">A message template that will be used to format the activity name.</param>
     /// <returns>A <see cref="LoggerActivity"/>.</returns>
     [MessageTemplateFormatMethod(nameof(messageTemplate))]
-    public static LoggerActivity StartActivity(this ILogger logger, ActivityContext parentContext, ActivityKind kind, LogEventLevel level, string messageTemplate)
+    public static LoggerActivity StartActivity(this ILogger logger, ActivityKind kind, ActivityContext parentContext, LogEventLevel level, string messageTemplate)
     {
-        return !TryStartActivity(logger, parentContext, kind, level, messageTemplate, out var activity) ?
+        return !TryStartActivity(logger, kind, parentContext, level, messageTemplate, out var activity) ?
             LoggerActivity.None :
             BindLoggerActivity(logger, level, messageTemplate, [], activity, kind);
     }
@@ -137,8 +137,8 @@ public static class LoggerTracingExtensions
     /// <param name="messageTemplate">A message template that will be used to format the activity name.</param>
     /// <returns>A <see cref="LoggerActivity"/>.</returns>
     [MessageTemplateFormatMethod(nameof(messageTemplate))]
-    public static LoggerActivity StartActivity(this ILogger logger, ActivityContext parentContext, ActivityKind kind, string messageTemplate)
-        => StartActivity(logger, parentContext, kind, LogEventLevel.Information, messageTemplate);
+    public static LoggerActivity StartActivity(this ILogger logger, ActivityKind kind, ActivityContext parentContext, string messageTemplate)
+        => StartActivity(logger, kind, parentContext, LogEventLevel.Information, messageTemplate);
 
     /// <summary>
     /// Start an activity.

--- a/src/SerilogTracing/LoggerTracingExtensions.cs
+++ b/src/SerilogTracing/LoggerTracingExtensions.cs
@@ -34,7 +34,7 @@ public static class LoggerTracingExtensions
     static readonly MessageTemplate FallbackTemplate = new MessageTemplateParser().Parse($"{{{FallbackTemplateOriginalTemplateName}}}");
 
     // This method checks preconditions for starting an activity, before a params array or `LoggerActivity` might need to be allocated.
-    static bool TryStartActivity(ILogger logger, LogEventLevel level, string messageTemplate, [NotNullWhen(true)] out Activity? activity)
+    static bool TryStartActivity(ILogger logger, ActivityContext parentContext, LogEventLevel level, string messageTemplate, [NotNullWhen(true)] out Activity? activity)
     {
         if (logger == null! || messageTemplate == null!)
         {
@@ -48,7 +48,7 @@ public static class LoggerTracingExtensions
             return false;
         }
 
-        activity = LoggerActivitySource.TryStartActivity(messageTemplate);
+        activity = LoggerActivitySource.TryStartActivity(messageTemplate, ActivityKind.Internal, parentContext);
         return activity != null;
     }
 
@@ -64,6 +64,77 @@ public static class LoggerTracingExtensions
 
         return new LoggerActivity(logger, level, activity, parsedTemplate, captures);
     }
+    
+    /// <summary>
+    /// Start an activity.
+    /// </summary>
+    /// <param name="logger">The logger that the resulting span will be written to, when the activity
+    /// is completed using <see cref="LoggerActivity.Complete"/> or <see cref="LoggerActivity.Dispose"/>.</param>
+    /// <param name="parentContext">The context to use as the parent on the resulting activity. This parameter is
+    /// useful for propagation, so <see cref="ActivityContext.IsRemote" /> should typically be true.</param>
+    /// <param name="level">The <see cref="LogEventLevel"/> of the <see cref="LogEvent"/> generated when the activity
+    /// is completed. The <see cref="LoggerActivity.Complete"/> method can be used to override this with
+    /// a higher level, but the level cannot be lowered at completion. If the <paramref name="logger"/> is configured
+    /// to ignore the given level then this method will not start an activity.</param>
+    /// <param name="messageTemplate">A message template that will be used to format the activity name.</param>
+    /// <param name="propertyValues">Values to substitute into the <paramref name="messageTemplate"/> placeholders.
+    /// These properties will also be attached to the resulting span.</param>
+    /// <returns>A <see cref="LoggerActivity"/>.</returns>
+    [MessageTemplateFormatMethod(nameof(messageTemplate))]
+    public static LoggerActivity StartActivity(this ILogger logger, ActivityContext parentContext, LogEventLevel level, string messageTemplate, params object?[]? propertyValues)
+    {
+        return !TryStartActivity(logger, parentContext, level, messageTemplate, out var activity) ?
+            LoggerActivity.None :
+            BindLoggerActivity(logger, level, messageTemplate, propertyValues, activity);
+    }
+
+    /// <summary>
+    /// Start an activity.
+    /// </summary>
+    /// <param name="logger">The logger that the resulting span will be written to, when the activity
+    /// is completed using <see cref="LoggerActivity.Complete"/> or <see cref="LoggerActivity.Dispose"/>.</param>
+    /// <param name="parentContext">The context to use as the parent on the resulting activity. This parameter is
+    /// useful for propagation, so <see cref="ActivityContext.IsRemote" /> should typically be true.</param>
+    /// <param name="messageTemplate">A message template that will be used to format the activity name.</param>
+    /// <param name="propertyValues">Values to substitute into the <paramref name="messageTemplate"/> placeholders.
+    /// These properties will also be attached to the resulting span.</param>
+    /// <returns>A <see cref="LoggerActivity"/>.</returns>
+    [MessageTemplateFormatMethod(nameof(messageTemplate))]
+    public static LoggerActivity StartActivity(this ILogger logger, ActivityContext parentContext, string messageTemplate, params object?[]? propertyValues)
+        => StartActivity(logger, parentContext, LogEventLevel.Information, messageTemplate, propertyValues);
+
+    /// <summary>
+    /// Start an activity.
+    /// </summary>
+    /// <param name="logger">The logger that the resulting span will be written to, when the activity
+    /// is completed using <see cref="LoggerActivity.Complete"/> or <see cref="LoggerActivity.Dispose"/>.</param>
+    /// <param name="parentContext">The context to use as the parent on the resulting activity. This parameter is
+    /// useful for propagation, so <see cref="ActivityContext.IsRemote" /> should typically be true.</param>
+    /// <param name="level">The <see cref="LogEventLevel"/> of the <see cref="LogEvent"/> generated when the activity
+    /// is completed. The <see cref="LoggerActivity.Complete"/> method can be used to override this with
+    /// a higher level, but the level cannot be lowered at completion.</param>
+    /// <param name="messageTemplate">A message template that will be used to format the activity name.</param>
+    /// <returns>A <see cref="LoggerActivity"/>.</returns>
+    [MessageTemplateFormatMethod(nameof(messageTemplate))]
+    public static LoggerActivity StartActivity(this ILogger logger, ActivityContext parentContext, LogEventLevel level, string messageTemplate)
+    {
+        return !TryStartActivity(logger, parentContext, level, messageTemplate, out var activity) ?
+            LoggerActivity.None :
+            BindLoggerActivity(logger, level, messageTemplate, [], activity);
+    }
+
+    /// <summary>
+    /// Start an activity.
+    /// </summary>
+    /// <param name="logger">The logger that the resulting span will be written to, when the activity
+    /// is completed using <see cref="LoggerActivity.Complete"/> or <see cref="LoggerActivity.Dispose"/>.</param>
+    /// <param name="parentContext">The context to use as the parent on the resulting activity. This parameter is
+    /// useful for propagation, so <see cref="ActivityContext.IsRemote" /> should typically be true.</param>
+    /// <param name="messageTemplate">A message template that will be used to format the activity name.</param>
+    /// <returns>A <see cref="LoggerActivity"/>.</returns>
+    [MessageTemplateFormatMethod(nameof(messageTemplate))]
+    public static LoggerActivity StartActivity(this ILogger logger, ActivityContext parentContext, string messageTemplate)
+        => StartActivity(logger, parentContext, LogEventLevel.Information, messageTemplate);
 
     /// <summary>
     /// Start an activity.
@@ -81,7 +152,7 @@ public static class LoggerTracingExtensions
     [MessageTemplateFormatMethod(nameof(messageTemplate))]
     public static LoggerActivity StartActivity(this ILogger logger, LogEventLevel level, string messageTemplate, params object?[]? propertyValues)
     {
-        return !TryStartActivity(logger, level, messageTemplate, out var activity) ?
+        return !TryStartActivity(logger, default, level, messageTemplate, out var activity) ?
             LoggerActivity.None :
             BindLoggerActivity(logger, level, messageTemplate, propertyValues, activity);
     }
@@ -112,7 +183,7 @@ public static class LoggerTracingExtensions
     [MessageTemplateFormatMethod(nameof(messageTemplate))]
     public static LoggerActivity StartActivity(this ILogger logger, LogEventLevel level, string messageTemplate)
     {
-        return !TryStartActivity(logger, level, messageTemplate, out var activity) ?
+        return !TryStartActivity(logger, default, level, messageTemplate, out var activity) ?
             LoggerActivity.None :
             BindLoggerActivity(logger, level, messageTemplate, [], activity);
     }
@@ -143,7 +214,7 @@ public static class LoggerTracingExtensions
     [MessageTemplateFormatMethod(nameof(messageTemplate))]
     public static LoggerActivity StartActivity<T>(this ILogger logger, LogEventLevel level, string messageTemplate, T propertyValue)
     {
-        return !TryStartActivity(logger, level, messageTemplate, out var activity) ?
+        return !TryStartActivity(logger, default, level, messageTemplate, out var activity) ?
             LoggerActivity.None :
             BindLoggerActivity(logger, level, messageTemplate, [propertyValue], activity);
     }
@@ -177,7 +248,7 @@ public static class LoggerTracingExtensions
     [MessageTemplateFormatMethod(nameof(messageTemplate))]
     public static LoggerActivity StartActivity<T0, T1>(this ILogger logger, LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
     {
-        return !TryStartActivity(logger, level, messageTemplate, out var activity) ?
+        return !TryStartActivity(logger, default, level, messageTemplate, out var activity) ?
             LoggerActivity.None :
             BindLoggerActivity(logger, level, messageTemplate, [propertyValue0, propertyValue1], activity);
     }
@@ -213,7 +284,7 @@ public static class LoggerTracingExtensions
     [MessageTemplateFormatMethod(nameof(messageTemplate))]
     public static LoggerActivity StartActivity<T0, T1, T2>(this ILogger logger, LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
     {
-        return !TryStartActivity(logger, level, messageTemplate, out var activity) ?
+        return !TryStartActivity(logger, default, level, messageTemplate, out var activity) ?
             LoggerActivity.None :
             BindLoggerActivity(logger, level, messageTemplate, [propertyValue0, propertyValue1, propertyValue2], activity);
     }

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -34,13 +34,13 @@ namespace SerilogTracing
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
         public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, Serilog.Events.LogEventLevel level, string messageTemplate, params object?[]? propertyValues) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
-        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, System.Diagnostics.ActivityKind kind, string messageTemplate) { }
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityKind kind, System.Diagnostics.ActivityContext parentContext, string messageTemplate) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
-        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, System.Diagnostics.ActivityKind kind, Serilog.Events.LogEventLevel level, string messageTemplate) { }
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityKind kind, System.Diagnostics.ActivityContext parentContext, Serilog.Events.LogEventLevel level, string messageTemplate) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
-        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, System.Diagnostics.ActivityKind kind, string messageTemplate, params object?[]? propertyValues) { }
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityKind kind, System.Diagnostics.ActivityContext parentContext, string messageTemplate, params object?[]? propertyValues) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
-        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, System.Diagnostics.ActivityKind kind, Serilog.Events.LogEventLevel level, string messageTemplate, params object?[]? propertyValues) { }
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityKind kind, System.Diagnostics.ActivityContext parentContext, Serilog.Events.LogEventLevel level, string messageTemplate, params object?[]? propertyValues) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
         public static SerilogTracing.LoggerActivity StartActivity<T>(this Serilog.ILogger logger, string messageTemplate, T propertyValue) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -30,17 +30,17 @@ namespace SerilogTracing
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
         public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, Serilog.Events.LogEventLevel level, string messageTemplate) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
-        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, string messageTemplate) { }
-        [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
         public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, string messageTemplate, params object?[]? propertyValues) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
         public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, Serilog.Events.LogEventLevel level, string messageTemplate, params object?[]? propertyValues) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
-        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, Serilog.Events.LogEventLevel level, string messageTemplate) { }
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, System.Diagnostics.ActivityKind kind, string messageTemplate) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
-        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, string messageTemplate, params object?[]? propertyValues) { }
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, System.Diagnostics.ActivityKind kind, Serilog.Events.LogEventLevel level, string messageTemplate) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
-        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, Serilog.Events.LogEventLevel level, string messageTemplate, params object?[]? propertyValues) { }
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, System.Diagnostics.ActivityKind kind, string messageTemplate, params object?[]? propertyValues) { }
+        [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, System.Diagnostics.ActivityKind kind, Serilog.Events.LogEventLevel level, string messageTemplate, params object?[]? propertyValues) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
         public static SerilogTracing.LoggerActivity StartActivity<T>(this Serilog.ILogger logger, string messageTemplate, T propertyValue) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]

--- a/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
+++ b/test/SerilogTracing.PublicApi.Tests/SerilogTracing.approved.txt
@@ -30,9 +30,17 @@ namespace SerilogTracing
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
         public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, Serilog.Events.LogEventLevel level, string messageTemplate) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, string messageTemplate) { }
+        [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
         public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, string messageTemplate, params object?[]? propertyValues) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
         public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, Serilog.Events.LogEventLevel level, string messageTemplate, params object?[]? propertyValues) { }
+        [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, Serilog.Events.LogEventLevel level, string messageTemplate) { }
+        [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, string messageTemplate, params object?[]? propertyValues) { }
+        [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
+        public static SerilogTracing.LoggerActivity StartActivity(this Serilog.ILogger logger, System.Diagnostics.ActivityContext parentContext, Serilog.Events.LogEventLevel level, string messageTemplate, params object?[]? propertyValues) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]
         public static SerilogTracing.LoggerActivity StartActivity<T>(this Serilog.ILogger logger, string messageTemplate, T propertyValue) { }
         [Serilog.Core.MessageTemplateFormatMethod("messageTemplate")]

--- a/test/SerilogTracing.Tests/LoggerActivityTests.cs
+++ b/test/SerilogTracing.Tests/LoggerActivityTests.cs
@@ -96,10 +96,4 @@ public class LoggerActivityTests
         var span = sink.SingleEvent;
         Assert.DoesNotContain("Discarded", span.Properties);
     }
-
-    [Fact]
-    public void ParentContextIsUsed()
-    {
-        throw new NotImplementedException();
-    }
 }

--- a/test/SerilogTracing.Tests/LoggerActivityTests.cs
+++ b/test/SerilogTracing.Tests/LoggerActivityTests.cs
@@ -96,4 +96,10 @@ public class LoggerActivityTests
         var span = sink.SingleEvent;
         Assert.DoesNotContain("Discarded", span.Properties);
     }
+
+    [Fact]
+    public void ParentContextIsUsed()
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/test/SerilogTracing.Tests/LoggerActivityTests.cs
+++ b/test/SerilogTracing.Tests/LoggerActivityTests.cs
@@ -29,12 +29,32 @@ public class LoggerActivityTests
         activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
         activity.Start();
 
-        var loggerActivity = new LoggerActivity(logger, initialLevel, activity, MessageTemplate.Empty, []);
+        var loggerActivity = new LoggerActivity(logger, initialLevel, activity, default, MessageTemplate.Empty, []);
         loggerActivity.Complete(completionLevel);
 
         var span = sink.SingleEvent;
         Assert.Equal(expectedLevel, span.Level);
         Assert.Equal(expectedStatusCode, activity.Status);
+    }
+    
+    [Fact]
+    public void ExpectedKindIsUsed()
+    {
+        var sink = new CollectingSink();
+
+        var logger = new LoggerConfiguration()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        using var activity = Some.Activity();
+        activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
+        activity.Start();
+
+        var loggerActivity = new LoggerActivity(logger, LogEventLevel.Information, activity, ActivityKind.Producer, MessageTemplate.Empty, []);
+        loggerActivity.Complete();
+
+        var span = sink.SingleEvent;
+        Assert.Equal(ActivityKind.Producer.ToString(), span.Properties["SpanKind"].ToString());
     }
 
     [Fact]
@@ -50,7 +70,7 @@ public class LoggerActivityTests
         using var activity = Some.Activity();
         activity.Start();
 
-        var loggerActivity = new LoggerActivity(logger, LogEventLevel.Information, activity, MessageTemplate.Empty, []);
+        var loggerActivity = new LoggerActivity(logger, LogEventLevel.Information, activity, default, MessageTemplate.Empty, []);
         loggerActivity.Dispose();
 
         Assert.Equal(ActivityStatusCode.Unset, activity.Status);
@@ -66,7 +86,7 @@ public class LoggerActivityTests
             .WriteTo.Sink(sink)
             .CreateLogger();
 
-        var loggerActivity = new LoggerActivity(logger, LogEventLevel.Information, null, MessageTemplate.Empty, []);
+        var loggerActivity = new LoggerActivity(logger, LogEventLevel.Information, null, default, MessageTemplate.Empty, []);
         loggerActivity.Complete(LogEventLevel.Information);
 
         Assert.Empty(sink.Events);
@@ -87,7 +107,7 @@ public class LoggerActivityTests
         activity.IsAllDataRequested = false;
         activity.Start();
 
-        var loggerActivity = new LoggerActivity(logger, LogEventLevel.Information, activity, MessageTemplate.Empty, []);
+        var loggerActivity = new LoggerActivity(logger, LogEventLevel.Information, activity, default, MessageTemplate.Empty, []);
 
         loggerActivity.AddProperty("Discarded", true);
 

--- a/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
+++ b/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
@@ -109,7 +109,7 @@ public class LoggerTracingExtensionsTests
         );
         
         var activity = log
-            .StartActivity(parentContext, default, Some.String());
+            .StartActivity(ActivityKind.Internal, parentContext, Some.String());
         
         Assert.Equal(parentContext.SpanId, activity.Activity!.ParentSpanId);
         Assert.Equal(parentContext.TraceId, activity.Activity!.TraceId);

--- a/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
+++ b/test/SerilogTracing.Tests/LoggerTracingExtensionsTests.cs
@@ -109,7 +109,7 @@ public class LoggerTracingExtensionsTests
         );
         
         var activity = log
-            .StartActivity(parentContext, Some.String());
+            .StartActivity(parentContext, default, Some.String());
         
         Assert.Equal(parentContext.SpanId, activity.Activity!.ParentSpanId);
         Assert.Equal(parentContext.TraceId, activity.Activity!.TraceId);


### PR DESCRIPTION
This PR adds overloads to `Logger.StartActivity` that accept an `ActivityContext` for the parent. This is necessary when using `Logger.StartActivity` with a propagated parent context.