### PR TITLE
Properly parse traceflags in ASP.NET Core instrumentation

### DIFF
--- a/test/SerilogTracing.Instrumentation.AspNetCore.Tests/TraceParentHeaderTests.cs
+++ b/test/SerilogTracing.Instrumentation.AspNetCore.Tests/TraceParentHeaderTests.cs
@@ -9,7 +9,13 @@ public class TraceParentHeaderTests
     [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", true, ActivityTraceFlags.Recorded)]
     [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00", true, ActivityTraceFlags.None)]
     [InlineData("notatraceparent", false, null)]
-    [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-02", false, null)]
+    [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-0x3", false, null)]
+    [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-0-2", false, null)]
+    [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331--2", false, null)]
+    [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-02", true, (ActivityTraceFlags)0b10)]
+    [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03", true, ActivityTraceFlags.Recorded | (ActivityTraceFlags)0b10)]
+    [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-ff", true, (ActivityTraceFlags)0xff)]
+    [InlineData("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-03", true, ActivityTraceFlags.Recorded)]
     public void FlagsAreParsed(string header, bool expectedResult, ActivityTraceFlags? expectedFlags)
     {
         Assert.Equal(expectedResult, TraceParentHeader.TryParse(header, out var flags));


### PR DESCRIPTION
The https://www.w3.org/TR/trace-context specification lays out some guidelines far how services should treat traceparent headers in a forwards compatible way. You can't assume that traceflags `00` means unsampled and `01` means sampled, since the flags are hex encoded, `03` is also sampled, and so is `55`.