### PR TITLE
Prevent adding HttpRequestOutActivityInstrumentor with default implementation additionaly

### DIFF
--- a/example/Example.WeatherService/Program.cs
+++ b/example/Example.WeatherService/Program.cs
@@ -23,6 +23,7 @@ using var _ = new ActivityListenerConfiguration()
         opts.IncomingTraceParent = IncomingTraceParent.Trust;
         opts.PostSamplingFilter = httpContext => !httpContext.Request.Path.StartsWithSegments("/health");
     })
+    // When '.Instrument.HttpClientRequests()' is called you need to ensure that '.Instrument.WithDefaultInstrumentation(false)' is called first!
     .TraceToSharedLogger();
 
 Log.Information("Weather service starting up");

--- a/src/SerilogTracing/Configuration/ActivityListenerInstrumentationConfiguration.cs
+++ b/src/SerilogTracing/Configuration/ActivityListenerInstrumentationConfiguration.cs
@@ -70,8 +70,11 @@ public sealed class ActivityListenerInstrumentationConfiguration
             {
                 throw new ArgumentNullException(nameof(instrumentors));
             }
-
-            _instrumentors.Add(instrumentor);
+            if (instrumentor is HttpRequestOutActivityInstrumentor && this._withDefaultInstrumentors == true)
+            {
+              throw new ArgumentException("Adding 'HttpRequestOutActivityInstrumentor' explicitly while 'WithDefaultInstrumentation' is true would lead to inconsistent behavior. Call 'WithDefaultInstrumentation(false)' to explicitly disable default instrumentation.");
+            }
+      _instrumentors.Add(instrumentor);
         }
 
         return _activityListenerConfiguration;

--- a/test/SerilogTracing.Tests/ActivityListenerConfigurationTests.cs
+++ b/test/SerilogTracing.Tests/ActivityListenerConfigurationTests.cs
@@ -6,9 +6,9 @@ namespace SerilogTracing.Tests;
 [Collection("Shared")]
 public class ActivityListenerConfigurationTests
 {
-    [Fact]
-    public void TracingConfigurationMethodsAreCallable()
-    {
+      [Fact]
+      public void TracingConfigurationMethodsAreCallable()
+      {
         // At this stage just covers some code paths that are
         // otherwise uncalled: not yet verifying outcomes, but
         // will at least pick up on obvious things like NREs.
@@ -20,5 +20,39 @@ public class ActivityListenerConfigurationTests
         configuration.Instrument.HttpClientRequests();
 
         configuration.Sample.Using((ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.None);
-    }
+      }
+
+      [Fact]
+      public void AddingHttpClientRequests_WhenWithDefaultInstrumentationIsTrue_Throws()
+      {
+        // Arrange
+        var configuration = new ActivityListenerConfiguration();
+        configuration.Instrument.WithDefaultInstrumentation(true);
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(
+            () => configuration.Instrument.HttpClientRequests()
+        );
+      }
+
+      [Fact]
+      public void AddingHttpClientRequests_WhenWithDefaultInstrumentationIsNotCalled_Throws()
+      {
+        // Arrange
+        var configuration = new ActivityListenerConfiguration();
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(
+            () => configuration.Instrument.HttpClientRequests()
+        );
+      }
+
+      [Fact]
+      public void AddingHttpClientRequests_WhenWithDefaultInstrumentationIsFalse_DoenstThrow()
+      {
+        // Arrange
+        var configuration = new ActivityListenerConfiguration();
+        configuration.Instrument.WithDefaultInstrumentation(false);
+        configuration.Instrument.HttpClientRequests();
+      }
 }


### PR DESCRIPTION
Changes made are here to prevent inconsistent behavior  when eg.
```csharp
using IDisposable tracingConfiguration = new ActivityListenerConfiguration()
          .Instrument.AspNetCoreRequests()
          .Instrument.HttpClientRequests(c => c.IsErrorResponse = (response) => (int)response.StatusCode >= 500)
          .TraceToSharedLogger();
```
In this Case there would be a 3 Instrumentors:
1. HttpClientRequests (default impl)
2. AspNetCore
3. HttpClientRequests (My implementation with 'IsErrorResponse ')

In Action the first Sequenz would correctly Not do `activity.SetStatus(ActivityStatusCode.Error);`
But with the 2nd 'HttpClientRequests ' de default implementation wold Set the ActivityStatusCode to .Error what resaults in a unintuitive behavior.

I currently cant foresee a case where i would need to have 2 different implementations one custom and one default

Test are provided for the exception.